### PR TITLE
BDOG-378 add support for a #NOT_SHUTTERABLE marker comment to the ngi…

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/model/FrontendRoutes.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/FrontendRoutes.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.serviceconfigs.persistence.model.{MongoFrontendRoute, MongoSh
 case class FrontendRoute(
  frontendPath: String,
  backendPath: String,
+ isShutterable: Boolean = true, //True unless the route contains the special #NOT_SHUTTERABLE comment
  shutterKillswitch: Option[ShutterSwitch] = None,
  shutterServiceSwitch: Option[ShutterSwitch] = None,
  ruleConfigurationUrl: String = "",
@@ -52,6 +53,7 @@ object FrontendRoute {
       ruleConfigurationUrl = mfr.ruleConfigurationUrl,
       shutterKillswitch    = mfr.shutterKillswitch.map(ShutterSwitch.fromMongo),
       shutterServiceSwitch = mfr.shutterServiceSwitch.map(ShutterSwitch.fromMongo),
+      isShutterable        = mfr.isShutterable,
       isRegex              = mfr.isRegex)
 }
 

--- a/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParser.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParser.scala
@@ -48,7 +48,7 @@ class NginxConfigParser @Inject() (nginxConfig: NginxConfig) extends FrontendRou
 
 
     def apply(tokens: Seq[NginxToken]): Either[String, List[FrontendRoute]] = {
-      val reader = new NginxTokenReader(tokens.filterNot(_.isInstanceOf[COMMENT]))
+      val reader = new NginxTokenReader(tokens)
       configFile(reader) match {
         case Success(result, _) => Right(result.flatMap {
           case l: LOCATION => locToRoute(l)
@@ -88,12 +88,16 @@ class NginxConfigParser @Inject() (nginxConfig: NginxConfig) extends FrontendRou
     def locToRoute(loc: LOCATION): Option[FrontendRoute] = {
       val ifs = loc.body.filter(_.isInstanceOf[IFBLOCK]).map(_.asInstanceOf[IFBLOCK])
 
+      // If the #NOT_SHUTTERABLE comment is present then the service has been explicitly marked
+      // as not shutterable. Otherwise, assume it is shutterable
+      val isShutterable = !loc.body.exists(_.isInstanceOf[NOT_SHUTTERABLE_COMMENT])
+
       val shutterKillswitch = extractKillSwitch(ifs)
       val shutterServiceSwitch = extractShutterSwitch(ifs)
 
       loc.body.find(_.isInstanceOf[PROXY_PASS]).map(_.asInstanceOf[PROXY_PASS].url).map(
         proxy => FrontendRoute(frontendPath = loc.path, backendPath = proxy, isRegex = loc.regex,
-          shutterKillswitch = shutterKillswitch, shutterServiceSwitch = shutterServiceSwitch)
+          isShutterable = isShutterable, shutterKillswitch = shutterKillswitch, shutterServiceSwitch = shutterServiceSwitch)
       )
     }
 
@@ -114,15 +118,20 @@ class NginxConfigParser @Inject() (nginxConfig: NginxConfig) extends FrontendRou
 
     case class RETURN(code: Int, url: Option[String]) extends PARAM
 
+    case class NOT_SHUTTERABLE_COMMENT() extends PARAM
+
     case class OTHER_PARAM(key: String, params: String*) extends PARAM
 
-    case class COMMENT_LINE() extends NGINX_AST
+    case class COMMENT_LINE() extends PARAM
 
     def keyword: Parser[KEYWORD] =
       accept("keyword", { case lit@KEYWORD(_) => lit })
 
     def value: Parser[VALUE] =
       accept("value", { case v@VALUE(_) => v })
+
+    def comment: Parser[COMMENT] =
+      accept("comment", { case c@COMMENT(_) => c })
 
     def parameter1: Parser[PARAM] = (keyword ~ rep1(value) <~ SEMICOLON()) ^^ {
       case KEYWORD("proxy_pass") ~ List(v) => PROXY_PASS(v.v)
@@ -138,7 +147,12 @@ class NginxConfigParser @Inject() (nginxConfig: NginxConfig) extends FrontendRou
       case kw ~ p1 ~ List(v) => OTHER_PARAM(kw.v, p1.v ++ v.v)
     }
 
-    def parameter: Parser[PARAM] = parameter1 | parameter2
+    def paramaterViaComment: Parser[PARAM] = comment ^^ {
+      case c if c.c == "#NOT_SHUTTERABLE" => NOT_SHUTTERABLE_COMMENT()
+      case _ => COMMENT_LINE()
+    }
+
+    def parameter: Parser[PARAM] = parameter1 | parameter2 | paramaterViaComment
 
     def block: Parser[List[NGINX_AST]] = rep1(parameter | context)
 
@@ -147,7 +161,6 @@ class NginxConfigParser @Inject() (nginxConfig: NginxConfig) extends FrontendRou
       case KEYWORD("location") ~  List(_, v) ~ _ ~ b ~ _ => LOCATION(v.v, b, regex = true)
       case KEYWORD("if") ~ cond ~ _ ~ b ~ _ => IFBLOCK(cond.map(_.v).mkString, b)
     }
-
 
     def configFile: NginxTokenParser.Parser[List[NGINX_AST]] = phrase(rep1(context | parameter))
   }
@@ -165,7 +178,7 @@ object Nginx {
 
   case class SEMICOLON() extends NginxToken
 
-  case class COMMENT() extends NginxToken
+  case class COMMENT(c: String) extends NginxToken
 
   case class KEYWORD(v: String) extends NginxToken
 
@@ -185,7 +198,7 @@ object NginxLexer extends RegexParsers {
 
   def semicolon: Parser[SEMICOLON] = ";" ^^ { _ => SEMICOLON() }
 
-  def comment: Parser[COMMENT] = "#.+".r ^^ { _ => COMMENT() }
+  def comment: Parser[COMMENT] = "#.+".r ^^ { c => COMMENT(c.trim) }
 
   def unquotedValue: Parser[VALUE] = """[^{}; ]+""".r ^^ (k => VALUE(k.trim))
 

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/model/MongoFrontendRoute.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/model/MongoFrontendRoute.scala
@@ -26,6 +26,7 @@ case class MongoFrontendRoute(
                                frontendPath: String,
                                backendPath : String,
                                environment : String,
+                               isShutterable     : Boolean = true,
                                shutterKillswitch: Option[MongoShutterSwitch] = None,
                                shutterServiceSwitch: Option[MongoShutterSwitch] = None,
                                ruleConfigurationUrl: String = "",

--- a/app/uk/gov/hmrc/serviceconfigs/service/NginxService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/NginxService.scala
@@ -97,7 +97,8 @@ object NginxService {
           backendPath          = r.backendPath,
           environment          = configFile.environment,
           ruleConfigurationUrl = NginxConfigIndexer.generateUrl(configFile.branch, configFile.environment, r.frontendPath, indexes).getOrElse(""),
-          shutterKillswitch = r.shutterKillswitch.map(ks => MongoShutterSwitch(ks.switchFile, ks.statusCode)),
+          isShutterable        = r.isShutterable,
+          shutterKillswitch    = r.shutterKillswitch.map(ks => MongoShutterSwitch(ks.switchFile, ks.statusCode)),
           shutterServiceSwitch = r.shutterServiceSwitch.map(s => MongoShutterSwitch(s.switchFile, s.statusCode, s.errorPage, s.rewriteRule)),
           isRegex              = r.isRegex))
       )

--- a/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.serviceconfigs.config.{NginxConfig, NginxShutterConfig}
 import uk.gov.hmrc.serviceconfigs.connector.NginxConfigConnector
 import uk.gov.hmrc.serviceconfigs.model.NginxConfigFile
 import uk.gov.hmrc.serviceconfigs.parser.NginxConfigParser
-import uk.gov.hmrc.serviceconfigs.persistence.model.MongoFrontendRoute
+import uk.gov.hmrc.serviceconfigs.persistence.model.MongoShutterSwitch
 import uk.gov.hmrc.serviceconfigs.persistence.{FrontendRouteRepo, MongoLock}
 import uk.gov.hmrc.serviceconfigs.service.NginxService
 
@@ -96,6 +96,7 @@ class NginxServiceSpec
 
   "parseConfig" should "turn an nginx config file into an indexed list of mongofrontendroutes" in {
 
+    when(nginxConfig.shutterConfig).thenReturn(NginxShutterConfig("/etc/nginx/switches/mdtp/offswitch", "/etc/nginx/switches/mdtp/"))
     val parser = new NginxConfigParser(nginxConfig)
 
     val configFile = NginxConfigFile(environment = "dev", "", testConfig)
@@ -110,12 +111,47 @@ class NginxServiceSpec
     result.head.frontendPath shouldBe "/test/assets"
     result.head.backendPath shouldBe "http://service1"
     result.head.ruleConfigurationUrl shouldBe "https://github.com/hmrc/mdtp-frontend-routes/blob/master/dev/frontend-proxy-application-rules.conf#L1"
+    result.head.isShutterable shouldBe true
+    result.head.shutterKillswitch shouldBe Some(MongoShutterSwitch("/etc/nginx/switches/mdtp/offswitch", Some(503), None, None))
+    result.head.shutterServiceSwitch shouldBe Some(MongoShutterSwitch("/etc/nginx/switches/mdtp/service1", Some(503), Some("/shutter/service1/index.html"), None))
 
     result(1).environment shouldBe "dev"
     result(1).service shouldBe "testservice"
     result(1).frontendPath shouldBe "/lol"
     result(1).backendPath shouldBe "http://testservice"
-    result(1).ruleConfigurationUrl shouldBe "https://github.com/hmrc/mdtp-frontend-routes/blob/master/dev/frontend-proxy-application-rules.conf#L7"
+    result(1).ruleConfigurationUrl shouldBe "https://github.com/hmrc/mdtp-frontend-routes/blob/master/dev/frontend-proxy-application-rules.conf#L17"
+    result(1).isShutterable shouldBe false
+    result(1).shutterKillswitch shouldBe None
+    result(1).shutterServiceSwitch shouldBe None
+
+  }
+
+  "parseConfig" should "ignore general comments" in {
+
+    val parser = new NginxConfigParser(nginxConfig)
+
+    val config = """location /lol {
+                       |  #this is a comment
+                       |  # here is another comment...
+                       |  more_set_headers '';
+                       |  proxy_pass http://testservice;
+                       |}""".stripMargin
+
+    val configFile = NginxConfigFile(environment = "dev", "", config)
+    val eResult = NginxService.parseConfig(parser, configFile)
+
+    eResult.isRight shouldBe true
+    val Right(result) = eResult
+    result.length shouldBe 1
+
+    result.head.environment shouldBe "dev"
+    result.head.service shouldBe "testservice"
+    result.head.frontendPath shouldBe "/lol"
+    result.head.backendPath shouldBe "http://testservice"
+    result.head.ruleConfigurationUrl shouldBe "https://github.com/hmrc/mdtp-frontend-routes/blob/master/dev/frontend-proxy-application-rules.conf#L1"
+    result.head.isShutterable shouldBe true
+    result.head.shutterKillswitch shouldBe None
+    result.head.shutterServiceSwitch shouldBe None
 
   }
 
@@ -123,9 +159,20 @@ class NginxServiceSpec
                  |  more_set_headers 'X-Frame-Options: DENY';
                  |  more_set_headers 'X-XSS-Protection: 1; mode=block';
                  |  more_set_headers 'X-Content-Type-Options: nosniff';
+                 |
+                 |  if ( -f /etc/nginx/switches/mdtp/offswitch )   {
+                 |    return 503;
+                 |  }
+                 |
+                 |  if ( -f /etc/nginx/switches/mdtp/service1 )   {
+                 |    error_page 503 /shutter/service1/index.html;
+                 |    return 503;
+                 |  }
+                 |
                  |  proxy_pass http://service1;
                  |}
                  |location /lol {
+                 |  #NOT_SHUTTERABLE
                  |  more_set_headers '';
                  |  proxy_pass http://testservice;
                  |}""".stripMargin

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxLexerSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxLexerSpec.scala
@@ -34,7 +34,7 @@ class NginxLexerSpec extends FlatSpec with Matchers{
   }
 
   it should "tokenize comments" in {
-    NginxLexer.parse(NginxLexer.comment, "# this is a comment").get shouldBe COMMENT()
+    NginxLexer.parse(NginxLexer.comment, "# this is a comment").get shouldBe COMMENT("# this is a comment")
   }
 
   it should "tokenize keywords" in {


### PR DESCRIPTION
…nx route parser

Adds a new flag to the nginx routes, `isShutterable`. This is true by default, but set to false if the location block contains a comment that matches `#NOT_SHUTTERABLE`.