### PR TITLE
BDOG-939 determine if a slug is latest when adding

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/model/SlugInfo.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/SlugInfo.scala
@@ -42,13 +42,13 @@ case class SlugDependency(
 
 case class SlugInfo(
   uri               : String,
-  created           : LocalDateTime,
+  created           : LocalDateTime, //not used
   name              : String,
   version           : Version,
-  teams             : List[String],
-  runnerVersion     : String,
+  teams             : List[String],  //not used
+  runnerVersion     : String,        //not used
   classpath         : String,
-  jdkVersion        : String,
+  jdkVersion        : String,        //not used
   dependencies      : List[SlugDependency],
   applicationConfig : String,
   slugConfig        : String,

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/SlugInfoRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/SlugInfoRepository.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.serviceconfigs.model.{MongoSlugInfoFormats, SlugInfo, SlugInf
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class SlugConfigurationInfoRepository @Inject()(
+class SlugInfoRepository @Inject()(
   mongoComponent: MongoComponent
 )( implicit ec: ExecutionContext
 ) extends PlayMongoRepository(

--- a/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
@@ -23,14 +23,14 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.serviceconfigs.connector.ConfigConnector
 import uk.gov.hmrc.serviceconfigs.model.{DependencyConfig, Environment, SlugInfoFlag}
 import uk.gov.hmrc.serviceconfigs.parser.ConfigParser
-import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, SlugConfigurationInfoRepository}
+import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, SlugInfoRepository}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfigService @Inject()(
   configConnector: ConfigConnector,
-  slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+  slugInfoRepository: SlugInfoRepository,
   dependencyConfigRepository: DependencyConfigRepository)(implicit ec: ExecutionContext) {
 
   import ConfigService._
@@ -68,7 +68,7 @@ class ConfigService @Inject()(
     environment.configSources.toList
       .foldLeftM[Future, Seq[ConfigSourceEntries]](Seq.empty) {
         case (seq, cs) =>
-          cs.entries(configConnector, slugConfigurationInfoRepository, dependencyConfigRepository)(
+          cs.entries(configConnector, slugInfoRepository, dependencyConfigRepository)(
               serviceName,
               environment.slugInfoFlag,
               getServiceType(seq))
@@ -124,7 +124,7 @@ object ConfigService {
 
     def entries(
       connector: ConfigConnector,
-      slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+      slugInfoRepository: SlugInfoRepository,
       dependencyConfigRepository: DependencyConfigRepository)(
       serviceName: String,
       slugInfoFlag: SlugInfoFlag,
@@ -139,7 +139,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,
@@ -147,7 +147,7 @@ object ConfigService {
         implicit hc: HeaderCarrier,
         ec: ExecutionContext): Future[ConfigSourceEntries] =
         for {
-          optSlugInfo     <- slugConfigurationInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
+          optSlugInfo     <- slugInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
           configs         <- optSlugInfo match {
                                case Some(slugInfo) =>
                                  slugInfo.dependencies.foldLeftM(List.empty[DependencyConfig]){ case (acc, d) =>
@@ -167,7 +167,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,
@@ -175,7 +175,7 @@ object ConfigService {
         implicit hc: HeaderCarrier,
         ec: ExecutionContext): Future[ConfigSourceEntries] =
         for {
-          optSlugInfo     <- slugConfigurationInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
+          optSlugInfo     <- slugInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
           configs         <- optSlugInfo match {
                                case Some(slugInfo) =>
                                  slugInfo.dependencies.foldLeftM(List.empty[DependencyConfig]){ case (acc, d) =>
@@ -200,7 +200,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,
@@ -208,7 +208,7 @@ object ConfigService {
         implicit hc: HeaderCarrier,
         ec: ExecutionContext): Future[ConfigSourceEntries] =
         for {
-          optSlugInfo <- slugConfigurationInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
+          optSlugInfo <- slugInfoRepository.getSlugInfo(serviceName, slugInfoFlag)
           raw         <- optSlugInfo match {
                            case Some(slugInfo) => Future(slugInfo.slugConfig)
                            case None           => connector.serviceConfigConf("base", serviceName) // if no slug info (e.g. java apps) get from github
@@ -224,7 +224,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,
@@ -246,7 +246,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,
@@ -269,7 +269,7 @@ object ConfigService {
 
       def entries(
         connector: ConfigConnector,
-        slugConfigurationInfoRepository: SlugConfigurationInfoRepository,
+        slugInfoRepository: SlugInfoRepository,
         dependencyConfigRepository: DependencyConfigRepository)(
         serviceName: String,
         slugInfoFlag: SlugInfoFlag,

--- a/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
@@ -23,14 +23,14 @@ import play.api.mvc.{Action, AnyContent, BodyParser, MessagesControllerComponent
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import uk.gov.hmrc.serviceconfigs.model.{DependencyConfig, SlugDependency, SlugInfo, Version}
 import uk.gov.hmrc.serviceconfigs.persistence.model.MongoFrontendRoute
-import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, FrontendRouteRepository, SlugConfigurationInfoRepository}
+import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, FrontendRouteRepository, SlugInfoRepository}
 
 import scala.concurrent.ExecutionContext
 
 class IntegrationTestController @Inject()(
   routeRepo           : FrontendRouteRepository,
   dependencyConfigRepo: DependencyConfigRepository,
-  slugRepo            : SlugConfigurationInfoRepository,
+  slugRepo            : SlugInfoRepository,
   mcc                 : MessagesControllerComponents
 )(implicit ec: ExecutionContext
 ) extends BackendController(mcc) {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -27,7 +27,7 @@ object AppDependencies {
     "org.scalatest"     %% "scalatest"               % "3.1.0"             % Test,
     "com.typesafe.play" %% "play-test"               % PlayVersion.current % Test,
     "org.mockito"       %  "mockito-core"            % "3.2.4"             % Test,
-    "org.scalatestplus" %% "scalatestplus-mockito"   % "1.0.0-M2"          % Test,
+    "org.mockito"       %% "mockito-scala-scalatest" % "1.13.10"           % Test,
     "com.typesafe.akka" %% "akka-testkit"            % "2.5.26"            % Test,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % hmrcMongoVersion    % Test
   )

--- a/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
@@ -16,23 +16,21 @@
 
 package uk.gov.hmrc.serviceconfigs
 
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
+import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import uk.gov.hmrc.serviceconfigs.config.{NginxConfig, NginxShutterConfig}
 import uk.gov.hmrc.serviceconfigs.connector.NginxConfigConnector
 import uk.gov.hmrc.serviceconfigs.model.NginxConfigFile
 import uk.gov.hmrc.serviceconfigs.parser.NginxConfigParser
-import uk.gov.hmrc.serviceconfigs.persistence.model.MongoShutterSwitch
 import uk.gov.hmrc.serviceconfigs.persistence.FrontendRouteRepository
+import uk.gov.hmrc.serviceconfigs.persistence.model.MongoShutterSwitch
 import uk.gov.hmrc.serviceconfigs.service.NginxService
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.DurationInt
 import scala.concurrent.Future
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration.DurationInt
 
 class NginxServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with ScalaFutures {
 
@@ -74,16 +72,16 @@ class NginxServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with 
         NginxConfigFile(environment = "production", "", testConfig, branch = "master")
       ))
 
-    when(repo.deleteByEnvironment(any()))
+    when(repo.deleteByEnvironment(any))
       .thenReturn(Future(true))
-    when(repo.update(any()))
+    when(repo.update(any))
       .thenReturn(Future.successful(()))
 
     val envs = List("production", "development")
     service.update(envs).futureValue
 
-    verify(repo, times(2)).update(any())
-    verify(connector, times(envs.length)).getNginxRoutesFile(any(), any())
+    verify(repo, times(2)).update(any)
+    verify(connector, times(envs.length)).getNginxRoutesFile(any, any)
   }
 
   "parseConfig" should "turn an nginx config file into an indexed list of mongofrontendroutes" in {

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParserSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParserSpec.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.serviceconfigs.parser
 
-import org.mockito.Mockito.when
+import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.serviceconfigs.config.{NginxConfig, NginxShutterConfig}
 import uk.gov.hmrc.serviceconfigs.model.{FrontendRoute, ShutterSwitch}
 

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxTokenParserTest.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxTokenParserTest.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.serviceconfigs.parser
 
-import org.mockito.Mockito.when
+import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.serviceconfigs.config.{NginxConfig, NginxShutterConfig}
 import uk.gov.hmrc.serviceconfigs.model.FrontendRoute
 

--- a/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.service
+
+import java.time.LocalDateTime
+
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.serviceconfigs.model._
+import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, SlugInfoRepository}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SlugConfigurationServiceSpec extends AnyWordSpec with Matchers
+  with ScalaFutures with MockitoSugar {
+
+  "SlugInfoService.addSlugInfo" should {
+    "mark the slug as latest if it is the first slug with that name" in {
+      val boot = Boot.init
+
+      val slug = sampleSlugInfo(version = Version("1.0.0"), uri = "uri1")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(any, any)).thenReturn(Future.successful(List.empty))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(()))
+      when(boot.mockedSlugInfoRepository.setFlag(any, any, any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(slug).futureValue
+
+      verify(boot.mockedSlugInfoRepository, times(1)).setFlag(SlugInfoFlag.Latest, slug.name, slug.version)
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+    "mark the slug as latest if the version is latest" in {
+      val boot = Boot.init
+
+      val slugv1 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(slugv2.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(()))
+      when(boot.mockedSlugInfoRepository.setFlag(any, any, any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+      verify(boot.mockedSlugInfoRepository, times(1)).setFlag(SlugInfoFlag.Latest, slugv1.name, Version("1.0.0"))
+
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+    "not use the latest flag from sqs/artefact processor" in {
+      val boot = Boot.init
+
+      val slugv1 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = sampleSlugInfo(version = Version("2.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(slugv2.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+
+      verify(boot.mockedSlugInfoRepository, times(1)).add(slugv1.copy(latest = false))
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+    "not mark the slug as latest if there is a later one already in the collection" in {
+      val boot = Boot.init
+
+      val slugv1 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = sampleSlugInfo(version = Version("2.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(slugv2.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+  }
+
+  def sampleSlugInfo(version: Version, uri: String, latest: Boolean = true): SlugInfo =
+    SlugInfo(
+      created = LocalDateTime.of(2019, 6, 28, 11, 51, 23),
+      uri = uri,
+      name = "my-slug",
+      version = version,
+      teams = List.empty,
+      runnerVersion = "0.5.2",
+      classpath = "",
+      jdkVersion = "1.181.0",
+      dependencies = List.empty,
+      applicationConfig = "",
+      slugConfig = "",
+      latest = latest)
+
+  case class Boot(
+                   mockedSlugInfoRepository : SlugInfoRepository
+                   , service                             : SlugConfigurationService
+                 )
+
+  object Boot {
+    def init: Boot = {
+      val mockedSlugInfoRepository              = mock[SlugInfoRepository]
+      val mockedDependencyConfigRepository      = mock[DependencyConfigRepository]
+      val mockedConfigService                   = mock[ConfigService]
+
+      val service = new SlugConfigurationService(
+        mockedSlugInfoRepository
+        , mockedDependencyConfigRepository
+        , mockedConfigService
+      )
+
+      Boot(
+        mockedSlugInfoRepository
+        , service
+      )
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
@@ -50,14 +50,14 @@ class SlugConfigurationServiceSpec extends AnyWordSpec with Matchers
       val boot = Boot.init
 
       val slugv1 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri1")
-      val slugv2 = sampleSlugInfo(version = Version("1.0.0"), uri = "uri2")
+      val slugv2 = sampleSlugInfo(version = Version("2.0.0"), uri = "uri2")
 
-      when(boot.mockedSlugInfoRepository.getSlugInfos(slugv2.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.getSlugInfos(slugv1.name, None)).thenReturn(Future.successful(List(slugv1, slugv2)))
       when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(()))
       when(boot.mockedSlugInfoRepository.setFlag(any, any, any)).thenReturn(Future.successful(()))
 
-      boot.service.addSlugInfo(slugv1).futureValue
-      verify(boot.mockedSlugInfoRepository, times(1)).setFlag(SlugInfoFlag.Latest, slugv1.name, Version("1.0.0"))
+      boot.service.addSlugInfo(slugv2).futureValue
+      verify(boot.mockedSlugInfoRepository, times(1)).setFlag(SlugInfoFlag.Latest, slugv2.name, Version("2.0.0"))
 
       verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
     }


### PR DESCRIPTION
1. Instead of using the latest flag set by artefact-processor verbatim, calculate and update latest when adding a new slug. This is an interim measure prior to BDOG-965 where we will review the interplay between the related services.