### PR TITLE
BDOG-1152: Fix persisting class path ordered dependencies in mongo

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationService.scala
@@ -34,7 +34,7 @@ class SlugConfigurationService @Inject()(
   private def classpathOrderedDependencies(slugInfo: SlugInfo): List[SlugDependency] =
     slugInfo.classpath
       .split(":")
-      .map(_.replace("$lib_dir/", s"./${slugInfo.name}-${slugInfo.version}/lib/"))
+      .map(_.replace("$lib_dir/", s"${slugInfo.name}-${slugInfo.version}/lib/"))
       .toList
       .flatMap(path => slugInfo.dependencies.filter(_.path == path))
 


### PR DESCRIPTION
There is a 🐛  in how we filter the classpath dependencies.

The data in `artefact-processor/slugInfo` collection is sent to service-configs via SQS queue. 

An excerpt from `artefact-processor/slugInfo`  (only relevant fields are kept, dependencies array is also trimmed)
```
{
  "_id": ObjectId( "5fc8c4bfd675ff33189857a3" ),
  "name": "internal-auth",
  "classpath": "$lib_dir/../conf/:$lib_dir/uk.gov.hmrc.internal-auth-0.26.0-sans-externalized.jar:$lib_dir/org.scala-lang.scala-library-2.12.11.jar:$lib_dir/com.typesafe.play.twirl-api_2.12-1.4.2.jar:$lib_dir/com.typesafe.play.play-server_2.12-2.7.5.jar",
  "dependencies": [
    {
      "path": "internal-auth-0.26.0/lib/com.google.inject.guice-4.2.2.jar",
      "version": "3.2.9",
      "group": "cglib",
      "artifact": "cglib",
      "meta": "fromPom"
    },
    {
      "path": "internal-auth-0.26.0/lib/org.reactivemongo.reactivemongo-play-json_2.12-0.18.8-play27.jar",
      "version": "0.18.8-play27",
      "group": "org.reactivemongo",
      "artifact": "reactivemongo-play-json",
      "meta": "fromManifest"
    }
  ]
}
```

The same data gets persisted in `service-configs/slugConfiguration` collection but with empty dependencies. The existing filtering logic was filtering out all the dependencies. This PR fixes it. 

There is a similar logic in [artefact-processor](https://github.com/hmrc/artefact-processor/blob/master/app/uk/gov/hmrc/artefactprocessor/models/SlugInfo.scala#L47) but the value `classpathOrderedDependencies ` was never used (that time and even in [future versions](https://github.com/hmrc/artefact-processor/compare/f734f5f262dd1f61504d14c66d0b474d39b72811...master))

Hopefully, this will remove the actual 🐛  as well (One step at a time 😄  )
