### PR TITLE
Provide `test-only` routes for deployment-config

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
@@ -53,4 +53,15 @@ object DeploymentConfig {
       ~ (__ \ "instances"   ).write[Int]
       )(unlift(DeploymentConfig.unapply))
   }
+
+  val apiReads: Reads[DeploymentConfig] = {
+    (   (__ \ "name"        ).read[String]
+      ~ (__ \ "artifactName").readNullable[String]
+      ~ (__ \ "environment" ).read[Environment](Environment.format)
+      ~ (__ \ "zone"        ).read[String]
+      ~ (__ \ "type"        ).read[String]
+      ~ (__ \ "slots"       ).read[Int]
+      ~ (__ \ "instances"   ).read[Int]
+      )(DeploymentConfig.apply _)
+  }
 }

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -16,4 +16,6 @@ POST       /test-only/slugDependencyConfigs  uk.gov.hmrc.serviceconfigs.testonly
 DELETE     /test-only/slugDependencyConfigs  uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugDependencyConfigs()
 POST       /test-only/sluginfos              uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addSlugs()
 DELETE     /test-only/sluginfos              uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugs()
+POST       /test-only/deploymentConfigs      uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addDeploymentConfigs()
+DELETE     /test-only/deploymentConfigs      uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteDeploymentConfigs()
 ->         /                                 prod.Routes


### PR DESCRIPTION
Some `test-only` routes to enable a new test in `catalogue-acceptance-tests`