### PR TITLE
BDOG: 1573—Introduce `DeploymentConfigSnapshot`s

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/ConfigJson.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/ConfigJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/Module.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/config/ArtefactReceivingConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/config/ArtefactReceivingConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/config/ArtifactoryConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/config/ArtifactoryConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/config/GithubConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/config/GithubConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/config/NginxConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/config/NginxConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/config/SchedulerConfigs.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/config/SchedulerConfigs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/ArtifactoryConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/ArtifactoryConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/BobbyConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/BobbyConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/ConfigConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/DeploymentConfigConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/DeploymentConfigConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/NginxConfigConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/NginxConfigConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/connector/ReleasesApiConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/ReleasesApiConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/AlertConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/AlertConfigController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/BobbyController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/BobbyController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/ConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/ConfigController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
@@ -56,12 +56,4 @@ class DeploymentConfigController @Inject()(
           .map(_.fold(NotFound(s"Service: $service not found"))(cfg => Ok(Json.toJson(cfg))))
       )
   }
-
-  def deploymentConfigHistoryForService(service: String): Action[AnyContent] =
-    Action.async {
-      deploymentConfigSnapshotRepository
-        .snapshotsForService(service)
-        .map(dch => Ok(Json.toJson(dch)))
-    }
-
 }

--- a/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/DeploymentConfigController.scala
@@ -31,7 +31,7 @@ class DeploymentConfigController @Inject()(deploymentConfigService: DeploymentCo
   implicit ec: ExecutionContext)
   extends BackendController(cc) {
 
-  implicit val dcw = DeploymentConfig.apiWrites
+  implicit val dcw = DeploymentConfig.apiFormat
 
   def deploymentConfigForEnv(environment: String): Action[AnyContent] = Action.async {
     Environment

--- a/app/uk/gov/hmrc/serviceconfigs/controller/NginxController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/NginxController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.controller
+
+import play.api.libs.json.{Format, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.serviceconfigs.service.{ResourceUsage, ResourceUsageService}
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class ResourceUsageController @Inject()(
+  resourceUsageService: ResourceUsageService,
+  cc: ControllerComponents
+  )(implicit ec: ExecutionContext) extends BackendController(cc) {
+
+  private implicit val resourceUsageFormat: Format[ResourceUsage] =
+    ResourceUsage.apiFormat
+
+  def historicResourceUsageForService(serviceName: String): Action[AnyContent] =
+    Action.async {
+      resourceUsageService
+        .resourceUsageForService(serviceName)
+        .map(r => Ok(Json.toJson(r)))
+    }
+}

--- a/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
@@ -32,10 +32,10 @@ class ResourceUsageController @Inject()(
   private implicit val resourceUsageFormat: Format[ResourceUsage] =
     ResourceUsage.apiFormat
 
-  def historicResourceUsageForService(serviceName: String): Action[AnyContent] =
+  def resourceUsageSnapshotsForService(serviceName: String): Action[AnyContent] =
     Action.async {
       resourceUsageService
-        .historicResourceUsageForService(serviceName)
+        .resourceUsageSnapshotsForService(serviceName)
         .map(r => Ok(Json.toJson(r)))
     }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/ResourceUsageController.scala
@@ -35,7 +35,7 @@ class ResourceUsageController @Inject()(
   def historicResourceUsageForService(serviceName: String): Action[AnyContent] =
     Action.async {
       resourceUsageService
-        .resourceUsageForService(serviceName)
+        .historicResourceUsageForService(serviceName)
         .map(r => Ok(Json.toJson(r)))
     }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/model/AlertEnvironmentHandler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/AlertEnvironmentHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfig.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.serviceconfigs.model
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, Reads, Writes, __}
+import play.api.libs.json.{Format, __}
 
 /*
  * Deployment config represents the non-application config from the app-config-env files.
@@ -43,25 +43,14 @@ object DeploymentConfig {
       ) (DeploymentConfig.apply, unlift(DeploymentConfig.unapply))
   }
 
-  val apiWrites: Writes[DeploymentConfig] = {
-    (   (__ \ "name"        ).write[String]
-      ~ (__ \ "artifactName").writeNullable[String]
-      ~ (__ \ "environment" ).write[Environment](Environment.format)
-      ~ (__ \ "zone"        ).write[String]
-      ~ (__ \ "type"        ).write[String]
-      ~ (__ \ "slots"       ).write[Int]
-      ~ (__ \ "instances"   ).write[Int]
-      )(unlift(DeploymentConfig.unapply))
-  }
-
-  val apiReads: Reads[DeploymentConfig] = {
-    (   (__ \ "name"        ).read[String]
-      ~ (__ \ "artifactName").readNullable[String]
-      ~ (__ \ "environment" ).read[Environment](Environment.format)
-      ~ (__ \ "zone"        ).read[String]
-      ~ (__ \ "type"        ).read[String]
-      ~ (__ \ "slots"       ).read[Int]
-      ~ (__ \ "instances"   ).read[Int]
-      )(DeploymentConfig.apply _)
+  val apiFormat: Format[DeploymentConfig] = {
+    (   (__ \ "name"        ).format[String]
+      ~ (__ \ "artifactName").formatNullable[String]
+      ~ (__ \ "environment" ).format[Environment](Environment.format)
+      ~ (__ \ "zone"        ).format[String]
+      ~ (__ \ "type"        ).format[String]
+      ~ (__ \ "slots"       ).format[Int]
+      ~ (__ \ "instances"   ).format[Int]
+      ) (DeploymentConfig.apply, unlift(DeploymentConfig.unapply))
   }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -16,20 +16,21 @@
 
 package uk.gov.hmrc.serviceconfigs.model
 
-import java.time.LocalDateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
+
+import java.time.Instant
 
 /**
   * A `DeploymentConfigSnapshot` represents a point-in-time snapshot of a `DeploymentConfig`
   *
-  * @param date The date the snapshot was taken
+  * @param timestamp The timestamp when the snapshot was taken
   * @param serviceName The name of the service
   * @param environment The environment the service is deployed in
   * @param deploymentConfig If present, the snapshot of the `DeploymentConfig`, or else indicates the removal of a service from an environment
   */
 final case class DeploymentConfigSnapshot(
-  date: LocalDateTime,
+  timestamp: Instant,
   serviceName: String,
   environment: Environment,
   deploymentConfig: Option[DeploymentConfig]
@@ -38,14 +39,14 @@ final case class DeploymentConfigSnapshot(
 object DeploymentConfigSnapshot {
 
   val mongoFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "date"             ).format[LocalDateTime]
+    (   (__ \ "timestamp"        ).format[Instant]
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "date"             ).format[LocalDateTime]
+    (   (__ \ "timestamp"        ).format[Instant]
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -21,32 +21,19 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
 
 final case class DeploymentConfigSnapshot(
-  name: String,
   date: LocalDate,
-  deploymentConfig: List[DeploymentConfig]
+  deploymentConfig: DeploymentConfig
 )
 
 object DeploymentConfigSnapshot {
 
-  val mongoFormat: Format[DeploymentConfigSnapshot] = {
-
-    implicit val deploymentConfigMongoFormat: Format[DeploymentConfig] =
-      DeploymentConfig.mongoFormat
-
-    (   (__ \ "name"             ).format[String]
-      ~ (__ \ "date"             ).format[LocalDate]
-      ~ (__ \ "deploymentConfig" ).format[List[DeploymentConfig]]
+  val mongoFormat: Format[DeploymentConfigSnapshot] =
+    (   (__ \ "date"             ).format[LocalDate]
+      ~ (__ \ "deploymentConfig" ).format[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
-  }
 
-  val apiFormat: Format[DeploymentConfigSnapshot] = {
-
-    implicit val deploymentConfigMongoFormat: Format[DeploymentConfig] =
-      DeploymentConfig.apiFormat
-
-    (   (__ \ "name"             ).format[String]
-      ~ (__ \ "date"             ).format[LocalDate]
-      ~ (__ \ "deploymentConfig" ).format[List[DeploymentConfig]]
+  val apiFormat: Format[DeploymentConfigSnapshot] =
+    (   (__ \ "date"             ).format[LocalDate]
+      ~ (__ \ "deploymentConfig" ).format[DeploymentConfig](DeploymentConfig.apiFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
-  }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -24,13 +24,13 @@ import play.api.libs.json.{Format, __}
   * A `DeploymentConfigSnapshot` represents a point-in-time snapshot of a `DeploymentConfig`
   *
   * @param date The date the snapshot was taken
-  * @param name The name of the service
+  * @param serviceName The name of the service
   * @param environment The environment the service is deployed in
   * @param deploymentConfig If present, the snapshot of the `DeploymentConfig`, or else indicates the removal of a service from an environment
   */
 final case class DeploymentConfigSnapshot(
   date: LocalDateTime,
-  name: String,
+  serviceName: String,
   environment: Environment,
   deploymentConfig: Option[DeploymentConfig]
 )
@@ -39,14 +39,14 @@ object DeploymentConfigSnapshot {
 
   val mongoFormat: Format[DeploymentConfigSnapshot] =
     (   (__ \ "date"             ).format[LocalDateTime]
-      ~ (__ \ "name"             ).format[String]
+      ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
     (   (__ \ "date"             ).format[LocalDateTime]
-      ~ (__ \ "name"             ).format[String]
+      ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -20,20 +20,34 @@ import java.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
 
+/**
+  * A `DeploymentConfigSnapshot` represents a point-in-time snapshot of a `DeploymentConfig`
+  *
+  * @param date The date the snapshot was taken
+  * @param name The name of the service
+  * @param environment The environment the service is deployed in
+  * @param deploymentConfig If present, the snapshot of the `DeploymentConfig`, or else indicates the removal of a service from an environment
+  */
 final case class DeploymentConfigSnapshot(
   date: LocalDate,
-  deploymentConfig: DeploymentConfig
+  name: String,
+  environment: Environment,
+  deploymentConfig: Option[DeploymentConfig]
 )
 
 object DeploymentConfigSnapshot {
 
   val mongoFormat: Format[DeploymentConfigSnapshot] =
     (   (__ \ "date"             ).format[LocalDate]
-      ~ (__ \ "deploymentConfig" ).format[DeploymentConfig](DeploymentConfig.mongoFormat)
+      ~ (__ \ "name"             ).format[String]
+      ~ (__ \ "environment"      ).format[Environment](Environment.format)
+      ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
     (   (__ \ "date"             ).format[LocalDate]
-      ~ (__ \ "deploymentConfig" ).format[DeploymentConfig](DeploymentConfig.apiFormat)
+      ~ (__ \ "name"             ).format[String]
+      ~ (__ \ "environment"      ).format[Environment](Environment.format)
+      ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 }

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.serviceconfigs.model
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
 
@@ -29,7 +29,7 @@ import play.api.libs.json.{Format, __}
   * @param deploymentConfig If present, the snapshot of the `DeploymentConfig`, or else indicates the removal of a service from an environment
   */
 final case class DeploymentConfigSnapshot(
-  date: LocalDate,
+  date: LocalDateTime,
   name: String,
   environment: Environment,
   deploymentConfig: Option[DeploymentConfig]
@@ -38,14 +38,14 @@ final case class DeploymentConfigSnapshot(
 object DeploymentConfigSnapshot {
 
   val mongoFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "date"             ).format[LocalDate]
+    (   (__ \ "date"             ).format[LocalDateTime]
       ~ (__ \ "name"             ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "date"             ).format[LocalDate]
+    (   (__ \ "date"             ).format[LocalDateTime]
       ~ (__ \ "name"             ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -18,19 +18,20 @@ package uk.gov.hmrc.serviceconfigs.model
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
 
 /**
   * A `DeploymentConfigSnapshot` represents a point-in-time snapshot of a `DeploymentConfig`
   *
-  * @param timestamp The timestamp when the snapshot was taken
+  * @param date The timestamp when the snapshot was taken
   * @param serviceName The name of the service
   * @param environment The environment the service is deployed in
   * @param deploymentConfig If present, the snapshot of the `DeploymentConfig`, or else indicates the removal of a service from an environment
   */
 final case class DeploymentConfigSnapshot(
-  timestamp: Instant,
+  date: Instant,
   serviceName: String,
   environment: Environment,
   deploymentConfig: Option[DeploymentConfig]
@@ -39,14 +40,14 @@ final case class DeploymentConfigSnapshot(
 object DeploymentConfigSnapshot {
 
   val mongoFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "timestamp"        ).format[Instant]
+    (   (__ \ "date"             ).format(MongoJavatimeFormats.instantFormat)
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.mongoFormat)
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "timestamp"        ).format[Instant]
+    (   (__ \ "date"             ).format(MongoJavatimeFormats.instantFormat)
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -38,4 +38,15 @@ object DeploymentConfigSnapshot {
       ~ (__ \ "deploymentConfig" ).format[List[DeploymentConfig]]
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
   }
+
+  val apiFormat: Format[DeploymentConfigSnapshot] = {
+
+    implicit val deploymentConfigMongoFormat: Format[DeploymentConfig] =
+      DeploymentConfig.apiFormat
+
+    (   (__ \ "name"             ).format[String]
+      ~ (__ \ "date"             ).format[LocalDate]
+      ~ (__ \ "deploymentConfig" ).format[List[DeploymentConfig]]
+      ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
+  }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.model
+
+import java.time.LocalDate
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, __}
+
+final case class DeploymentConfigSnapshot(
+  name: String,
+  date: LocalDate,
+  deploymentConfig: List[DeploymentConfig]
+)
+
+object DeploymentConfigSnapshot {
+
+  val mongoFormat: Format[DeploymentConfigSnapshot] = {
+
+    implicit val deploymentConfigMongoFormat: Format[DeploymentConfig] =
+      DeploymentConfig.mongoFormat
+
+    (   (__ \ "name"             ).format[String]
+      ~ (__ \ "date"             ).format[LocalDate]
+      ~ (__ \ "deploymentConfig" ).format[List[DeploymentConfig]]
+      ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
+  }
+}

--- a/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/DeploymentConfigSnapshot.scala
@@ -47,7 +47,7 @@ object DeploymentConfigSnapshot {
       ) (DeploymentConfigSnapshot.apply, unlift(DeploymentConfigSnapshot.unapply))
 
   val apiFormat: Format[DeploymentConfigSnapshot] =
-    (   (__ \ "date"             ).format(MongoJavatimeFormats.instantFormat)
+    (   (__ \ "date"             ).format[Instant]
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "deploymentConfig" ).formatNullable[DeploymentConfig](DeploymentConfig.apiFormat)

--- a/app/uk/gov/hmrc/serviceconfigs/model/Environment.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/Environment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/FrontendRoutes.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/FrontendRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/NginxConfigFile.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/NginxConfigFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/SlugInfo.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/SlugInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/model/Version.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/model/Version.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/parser/ConfigParser.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/parser/ConfigParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/parser/FrontendRouteParser.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/parser/FrontendRouteParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigIndexer.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigIndexer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParser.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/AlertConfigRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/AlertConfigRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DependencyConfigRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DependencyConfigRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -23,6 +23,8 @@ import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.serviceconfigs.model.DeploymentConfigSnapshot
 import org.mongodb.scala.model.Filters.{and, equal}
 import org.mongodb.scala.model.FindOneAndReplaceOptions
+import org.mongodb.scala.model.Indexes._
+import org.mongodb.scala.model.{IndexModel, IndexOptions}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +35,9 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     mongoComponent = mongoComponent,
     collectionName = "deploymentConfigSnapshots",
     domainFormat = DeploymentConfigSnapshot.mongoFormat,
-    indexes = Seq(),
+    indexes = Seq(
+      IndexModel(hashed("deploymentConfig.name"), IndexOptions().background(true)),
+      IndexModel(hashed("deploymentConfig.environment"), IndexOptions().background(true)))
   ) {
 
   def snapshotsForService(name: String): Future[Seq[DeploymentConfigSnapshot]] = {

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -43,7 +43,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
   def snapshotsForService(serviceName: String): Future[Seq[DeploymentConfigSnapshot]] = {
     val sortParams =
       BsonDocument(
-        ("timestamp", BsonInt32(1))
+        ("date", BsonInt32(1))
       )
 
     collection
@@ -58,7 +58,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
         filter = and(
           equal("serviceName", snapshot.serviceName),
           equal("environment", snapshot.environment.asString),
-          equal("timestamp", snapshot.timestamp)),
+          equal("date", snapshot.date)),
         replacement = snapshot,
         options = FindOneAndReplaceOptions().upsert(true))
       .toFutureOption()

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -36,8 +36,8 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     collectionName = "deploymentConfigSnapshots",
     domainFormat = DeploymentConfigSnapshot.mongoFormat,
     indexes = Seq(
-      IndexModel(hashed("deploymentConfig.name"), IndexOptions().background(true)),
-      IndexModel(hashed("deploymentConfig.environment"), IndexOptions().background(true)))
+      IndexModel(hashed("name"), IndexOptions().background(true)),
+      IndexModel(hashed("environment"), IndexOptions().background(true)))
   ) {
 
   def snapshotsForService(name: String): Future[Seq[DeploymentConfigSnapshot]] = {
@@ -47,7 +47,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
       )
 
     collection
-      .find(equal("deploymentConfig.name", name))
+      .find(equal("name", name))
       .sort(sortParams)
       .toFuture()
   }
@@ -56,8 +56,8 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     collection
       .findOneAndReplace(
         filter = and(
-          equal("deploymentConfig.name", snapshot.deploymentConfig.name),
-          equal("deploymentConfig.environment", snapshot.deploymentConfig.environment.asString),
+          equal("name", snapshot.name),
+          equal("environment", snapshot.environment.asString),
           equal("date", snapshot.date)),
         replacement = snapshot,
         options = FindOneAndReplaceOptions().upsert(true))

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.serviceconfigs.persistence
 
 import com.mongodb.BasicDBObject
-import org.mongodb.scala.bson.{BsonDocument, BsonInt32}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.serviceconfigs.model.DeploymentConfigSnapshot

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -43,7 +43,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
   def snapshotsForService(serviceName: String): Future[Seq[DeploymentConfigSnapshot]] = {
     val sortParams =
       BsonDocument(
-        ("date", BsonInt32(1))
+        ("timestamp", BsonInt32(1))
       )
 
     collection
@@ -58,7 +58,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
         filter = and(
           equal("serviceName", snapshot.serviceName),
           equal("environment", snapshot.environment.asString),
-          equal("date", snapshot.date)),
+          equal("timestamp", snapshot.timestamp)),
         replacement = snapshot,
         options = FindOneAndReplaceOptions().upsert(true))
       .toFutureOption()

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.persistence
+
+import com.mongodb.BasicDBObject
+import org.mongodb.scala.bson.{BsonDocument, BsonInt32}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.serviceconfigs.model.DeploymentConfigSnapshot
+import org.mongodb.scala.model.Filters.{and, equal}
+import org.mongodb.scala.model.FindOneAndReplaceOptions
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponent)(implicit ec: ExecutionContext)
+  extends PlayMongoRepository(
+    mongoComponent = mongoComponent,
+    collectionName = "deploymentConfigSnapshots",
+    domainFormat = DeploymentConfigSnapshot.mongoFormat,
+    indexes = Seq(),
+  ) {
+
+  def snapshotsForService(name: String): Future[Seq[DeploymentConfigSnapshot]] = {
+    val sortParams =
+      BsonDocument(
+        ("date", BsonInt32(1))
+      )
+
+    collection
+      .find(equal("name", name))
+      .sort(sortParams)
+      .toFuture()
+  }
+
+  def add(snapshot: DeploymentConfigSnapshot): Future[Unit] =
+    collection
+      .findOneAndReplace(
+        filter = and(
+          equal("name", snapshot.name),
+          equal("date", snapshot.date)),
+        replacement = snapshot,
+        options = FindOneAndReplaceOptions().upsert(true))
+      .toFutureOption()
+      .map(_ => ())
+
+  def deleteAll(): Future[Unit] =
+    collection
+      .deleteMany(new BasicDBObject())
+      .toFuture
+      .map(_ => ())
+}

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -36,18 +36,18 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     collectionName = "deploymentConfigSnapshots",
     domainFormat = DeploymentConfigSnapshot.mongoFormat,
     indexes = Seq(
-      IndexModel(hashed("name"), IndexOptions().background(true)),
+      IndexModel(hashed("serviceName"), IndexOptions().background(true)),
       IndexModel(hashed("environment"), IndexOptions().background(true)))
   ) {
 
-  def snapshotsForService(name: String): Future[Seq[DeploymentConfigSnapshot]] = {
+  def snapshotsForService(serviceName: String): Future[Seq[DeploymentConfigSnapshot]] = {
     val sortParams =
       BsonDocument(
         ("date", BsonInt32(1))
       )
 
     collection
-      .find(equal("name", name))
+      .find(equal("serviceName", serviceName))
       .sort(sortParams)
       .toFuture()
   }
@@ -56,7 +56,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     collection
       .findOneAndReplace(
         filter = and(
-          equal("name", snapshot.name),
+          equal("serviceName", snapshot.serviceName),
           equal("environment", snapshot.environment.asString),
           equal("date", snapshot.date)),
         replacement = snapshot,

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -22,9 +22,8 @@ import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.serviceconfigs.model.DeploymentConfigSnapshot
 import org.mongodb.scala.model.Filters.{and, equal}
-import org.mongodb.scala.model.FindOneAndReplaceOptions
+import org.mongodb.scala.model.{FindOneAndReplaceOptions, IndexModel, IndexOptions, Sorts}
 import org.mongodb.scala.model.Indexes._
-import org.mongodb.scala.model.{IndexModel, IndexOptions}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,17 +39,11 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
       IndexModel(hashed("environment"), IndexOptions().background(true)))
   ) {
 
-  def snapshotsForService(serviceName: String): Future[Seq[DeploymentConfigSnapshot]] = {
-    val sortParams =
-      BsonDocument(
-        ("date", BsonInt32(1))
-      )
-
+  def snapshotsForService(serviceName: String): Future[Seq[DeploymentConfigSnapshot]] =
     collection
       .find(equal("serviceName", serviceName))
-      .sort(sortParams)
+      .sort(Sorts.ascending("date"))
       .toFuture()
-  }
 
   def add(snapshot: DeploymentConfigSnapshot): Future[Unit] =
     collection

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepository.scala
@@ -43,7 +43,7 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
       )
 
     collection
-      .find(equal("name", name))
+      .find(equal("deploymentConfig.name", name))
       .sort(sortParams)
       .toFuture()
   }
@@ -52,7 +52,8 @@ class DeploymentConfigSnapshotRepository @Inject()(mongoComponent: MongoComponen
     collection
       .findOneAndReplace(
         filter = and(
-          equal("name", snapshot.name),
+          equal("deploymentConfig.name", snapshot.deploymentConfig.name),
+          equal("deploymentConfig.environment", snapshot.deploymentConfig.environment.asString),
           equal("date", snapshot.date)),
         replacement = snapshot,
         options = FindOneAndReplaceOptions().upsert(true))

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/SlugInfoRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/SlugInfoRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/SlugVersionRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/SlugVersionRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/YamlToBson.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/YamlToBson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/model/MongoFrontendRoute.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/model/MongoFrontendRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/AlertConfigScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/AlertConfigScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/DeploymentConfigScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/DeploymentConfigScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/FrontendRouteScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/FrontendRouteScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/SchedulerUtils.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/SchedulerUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/SlugMetadataUpdateScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/SlugMetadataUpdateScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/AlertConfigSchedulerService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/AlertConfigSchedulerService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/AlertConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/AlertConfigService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/BobbyService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/BobbyService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/DeadLetterHandler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/DeadLetterHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/DeploymentConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/DeploymentConfigService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/NginxService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/NginxService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Format, __}
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
 
-import java.time.LocalDateTime
+import java.time.Instant
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -36,7 +36,7 @@ class ResourceUsageService @Inject() (
 }
 
 final case class ResourceUsage(
-  date: LocalDateTime,
+  timestamp: Instant,
   serviceName: String,
   environment: Environment,
   slots: Int,
@@ -53,7 +53,7 @@ object ResourceUsage {
       deploymentConfigSnapshot.deploymentConfig.map(_.instances).getOrElse(0)
 
     ResourceUsage(
-      deploymentConfigSnapshot.date,
+      deploymentConfigSnapshot.timestamp,
       deploymentConfigSnapshot.serviceName,
       deploymentConfigSnapshot.environment,
       slots,
@@ -62,7 +62,7 @@ object ResourceUsage {
   }
 
   val apiFormat: Format[ResourceUsage] =
-    (   (__ \ "date"             ).format[LocalDateTime]
+    (   (__ \ "timestamp"        ).format[Instant]
       ~ (__ \ "serviceName"      ).format[String]
       ~ (__ \ "environment"      ).format[Environment](Environment.format)
       ~ (__ \ "slots"            ).format[Int]

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -56,8 +56,8 @@ object ResourceUsage {
       deploymentConfigSnapshot.timestamp,
       deploymentConfigSnapshot.serviceName,
       deploymentConfigSnapshot.environment,
-      slots,
-      instances
+      slots = slots,
+      instances = instances
     )
   }
 

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -30,7 +30,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ResourceUsageService @Inject() (
   deploymentConfigSnapshotRepository: DeploymentConfigSnapshotRepository)(implicit ec: ExecutionContext) {
 
-  def historicResourceUsageForService(serviceName: String): Future[Seq[ResourceUsage]] =
+  def resourceUsageSnapshotsForService(serviceName: String): Future[Seq[ResourceUsage]] =
     deploymentConfigSnapshotRepository
       .snapshotsForService(serviceName)
       .map(_.map(ResourceUsage.fromDeploymentConfigSnapshot))

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.serviceconfigs.service
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
 
@@ -36,7 +37,7 @@ class ResourceUsageService @Inject() (
 }
 
 final case class ResourceUsage(
-  timestamp: Instant,
+  date: Instant,
   serviceName: String,
   environment: Environment,
   slots: Int,
@@ -53,7 +54,7 @@ object ResourceUsage {
       deploymentConfigSnapshot.deploymentConfig.map(_.instances).getOrElse(0)
 
     ResourceUsage(
-      deploymentConfigSnapshot.timestamp,
+      deploymentConfigSnapshot.date,
       deploymentConfigSnapshot.serviceName,
       deploymentConfigSnapshot.environment,
       slots = slots,
@@ -62,10 +63,10 @@ object ResourceUsage {
   }
 
   val apiFormat: Format[ResourceUsage] =
-    (   (__ \ "timestamp"        ).format[Instant]
-      ~ (__ \ "serviceName"      ).format[String]
-      ~ (__ \ "environment"      ).format[Environment](Environment.format)
-      ~ (__ \ "slots"            ).format[Int]
-      ~ (__ \ "instances"        ).format[Int]
+    (   (__ \ "date"        ).format(MongoJavatimeFormats.instantFormat)
+      ~ (__ \ "serviceName" ).format[String]
+      ~ (__ \ "environment" ).format[Environment](Environment.format)
+      ~ (__ \ "slots"       ).format[Int]
+      ~ (__ \ "instances"   ).format[Int]
       ) (ResourceUsage.apply, unlift(ResourceUsage.unapply))
 }

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -41,11 +41,7 @@ final case class ResourceUsage(
   environment: Environment,
   slots: Int,
   instances: Int
-) {
-
-  val estimatedYearlyCostUsd: Double =
-    instances * 120
-}
+)
 
 object ResourceUsage {
 

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.service
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, __}
+import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfigSnapshot, Environment}
+import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
+
+import java.time.LocalDateTime
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ResourceUsageService @Inject() (
+  deploymentConfigSnapshotRepository: DeploymentConfigSnapshotRepository)(implicit ec: ExecutionContext) {
+
+  def resourceUsageForService(name: String): Future[Seq[ResourceUsage]] =
+    deploymentConfigSnapshotRepository
+      .snapshotsForService(name)
+      .map(_.map(ResourceUsage.fromDeploymentConfigSnapshot))
+}
+
+final case class ResourceUsage(
+  date: LocalDateTime,
+  serviceName: String,
+  environment: Environment,
+  slots: Int,
+  instances: Int
+) {
+
+  val estimatedYearlyCostUsd: Double =
+    instances * 120
+}
+
+object ResourceUsage {
+
+  def fromDeploymentConfigSnapshot(deploymentConfigSnapshot: DeploymentConfigSnapshot): ResourceUsage = {
+    val slots =
+      deploymentConfigSnapshot.deploymentConfig.map(_.slots).getOrElse(0)
+
+    val instances =
+      deploymentConfigSnapshot.deploymentConfig.map(_.instances).getOrElse(0)
+
+    ResourceUsage(
+      deploymentConfigSnapshot.date,
+      deploymentConfigSnapshot.name,
+      deploymentConfigSnapshot.environment,
+      slots,
+      instances
+    )
+  }
+
+  val apiFormat: Format[ResourceUsage] =
+    (   (__ \ "date"             ).format[LocalDateTime]
+      ~ (__ \ "serviceName"      ).format[String]
+      ~ (__ \ "environment"      ).format[Environment](Environment.format)
+      ~ (__ \ "slots"            ).format[Int]
+      ~ (__ \ "instances"        ).format[Int]
+      ) (ResourceUsage.apply, unlift(ResourceUsage.unapply))
+}

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -29,9 +29,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class ResourceUsageService @Inject() (
   deploymentConfigSnapshotRepository: DeploymentConfigSnapshotRepository)(implicit ec: ExecutionContext) {
 
-  def resourceUsageForService(name: String): Future[Seq[ResourceUsage]] =
+  def historicResourceUsageForService(serviceName: String): Future[Seq[ResourceUsage]] =
     deploymentConfigSnapshotRepository
-      .snapshotsForService(name)
+      .snapshotsForService(serviceName)
       .map(_.map(ResourceUsage.fromDeploymentConfigSnapshot))
 }
 

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.serviceconfigs.service
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, __}
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
 
@@ -63,7 +62,7 @@ object ResourceUsage {
   }
 
   val apiFormat: Format[ResourceUsage] =
-    (   (__ \ "date"        ).format(MongoJavatimeFormats.instantFormat)
+    (   (__ \ "date"        ).format[Instant]
       ~ (__ \ "serviceName" ).format[String]
       ~ (__ \ "environment" ).format[Environment](Environment.format)
       ~ (__ \ "slots"       ).format[Int]

--- a/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ResourceUsageService.scala
@@ -54,7 +54,7 @@ object ResourceUsage {
 
     ResourceUsage(
       deploymentConfigSnapshot.date,
-      deploymentConfigSnapshot.name,
+      deploymentConfigSnapshot.serviceName,
       deploymentConfigSnapshot.environment,
       slots,
       instances

--- a/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigUpdateHandler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigUpdateHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/SlugInfoService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/service/SqsMessageHandling.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/SqsMessageHandling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
@@ -45,7 +45,7 @@ class IntegrationTestController @Inject()(
   implicit val siwfr: Reads[SlugInfoWithFlags] = SlugInfoWithFlags.reads
 
   implicit val deploymentConfigReads: Reads[DeploymentConfig] =
-    DeploymentConfig.apiReads
+    DeploymentConfig.apiFormat
 
   def validateJson[A: Reads]: BodyParser[A] =
     parse.json.validate(

--- a/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/testonly/IntegrationTestController.scala
@@ -22,18 +22,19 @@ import javax.inject.Inject
 import play.api.libs.json.{JsError, Json, Reads}
 import play.api.mvc.{Action, AnyContent, BodyParser, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import uk.gov.hmrc.serviceconfigs.model.{ApiSlugInfoFormats, DependencyConfig, DeploymentConfig, Environment, SlugInfo, SlugInfoFlag}
+import uk.gov.hmrc.serviceconfigs.model.{ApiSlugInfoFormats, DependencyConfig, DeploymentConfig, DeploymentConfigSnapshot, Environment, SlugInfo, SlugInfoFlag}
 import uk.gov.hmrc.serviceconfigs.persistence.model.MongoFrontendRoute
-import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, DeploymentConfigRepository, FrontendRouteRepository, SlugInfoRepository}
+import uk.gov.hmrc.serviceconfigs.persistence.{DependencyConfigRepository, DeploymentConfigRepository, DeploymentConfigSnapshotRepository, FrontendRouteRepository, SlugInfoRepository}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class IntegrationTestController @Inject()(
-  routeRepo            : FrontendRouteRepository,
-  dependencyConfigRepo : DependencyConfigRepository,
-  slugInfoRepo         : SlugInfoRepository,
-  deploymentConfigRepo : DeploymentConfigRepository,
-  mcc                  : MessagesControllerComponents
+  routeRepo                    : FrontendRouteRepository,
+  dependencyConfigRepo         : DependencyConfigRepository,
+  slugInfoRepo                 : SlugInfoRepository,
+  deploymentConfigRepo         : DeploymentConfigRepository,
+  deploymentConfigSnapshotRepo : DeploymentConfigSnapshotRepository,
+  mcc                          : MessagesControllerComponents
 )(implicit ec: ExecutionContext
 ) extends BackendController(mcc) {
 
@@ -46,6 +47,9 @@ class IntegrationTestController @Inject()(
 
   implicit val deploymentConfigReads: Reads[DeploymentConfig] =
     DeploymentConfig.apiFormat
+
+  implicit val deploymentConfigSnapshotReads: Reads[DeploymentConfigSnapshot] =
+    DeploymentConfigSnapshot.apiFormat
 
   def validateJson[A: Reads]: BodyParser[A] =
     parse.json.validate(
@@ -114,6 +118,18 @@ class IntegrationTestController @Inject()(
   def deleteDeploymentConfigs(): Action[AnyContent] =
     Action.async {
       deploymentConfigRepo.deleteAll().map(_ => Ok("Done"))
+    }
+
+  def addDeploymentConfigHistories(): Action[List[DeploymentConfigSnapshot]] =
+    Action.async(validateJson[List[DeploymentConfigSnapshot]]) { implicit request =>
+      request.body
+        .traverse(deploymentConfigSnapshotRepo.add)
+        .map(_ => Ok("Done"))
+    }
+
+  def deleteDeploymentConfigHistories(): Action[AnyContent] =
+    Action.async {
+      deploymentConfigSnapshotRepo.deleteAll().map(_ => Ok("Done"))
     }
 
   case class SlugInfoWithFlags(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -13,3 +13,5 @@ GET     /alert-configs/:serviceName             @uk.gov.hmrc.serviceconfigs.cont
 GET     /deployment-config/:environment         @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForEnv(environment)
 GET     /deployment-config/:environment/:name   @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForService(environment, name)
 GET     /deployment-config-history/:name        @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigHistoryForService(name)
+
+GET     /resource-usage/historic/:serviceName   @uk.gov.hmrc.serviceconfigs.controller.ResourceUsageController.historicResourceUsageForService(serviceName)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,6 +12,5 @@ GET     /alert-configs/:serviceName             @uk.gov.hmrc.serviceconfigs.cont
 
 GET     /deployment-config/:environment         @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForEnv(environment)
 GET     /deployment-config/:environment/:name   @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForService(environment, name)
-GET     /deployment-config-history/:name        @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigHistoryForService(name)
 
 GET     /resource-usage/historic/:serviceName   @uk.gov.hmrc.serviceconfigs.controller.ResourceUsageController.historicResourceUsageForService(serviceName)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,3 +12,4 @@ GET     /alert-configs/:serviceName             @uk.gov.hmrc.serviceconfigs.cont
 
 GET     /deployment-config/:environment         @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForEnv(environment)
 GET     /deployment-config/:environment/:name   @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForService(environment, name)
+GET     /deployment-config-history/:name        @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigHistoryForService(name)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,16 +1,16 @@
 # microservice specific routes
 
-GET     /config-by-env/:serviceName             @uk.gov.hmrc.serviceconfigs.controller.ConfigController.serviceConfig(serviceName)
-GET     /config-by-key/:serviceName             @uk.gov.hmrc.serviceconfigs.controller.ConfigController.configByKey(serviceName)
+GET     /config-by-env/:serviceName                     @uk.gov.hmrc.serviceconfigs.controller.ConfigController.serviceConfig(serviceName)
+GET     /config-by-key/:serviceName                     @uk.gov.hmrc.serviceconfigs.controller.ConfigController.configByKey(serviceName)
 
-GET     /frontend-route/search                  @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByFrontendPath(frontendPath: String)
-GET     /frontend-route-by-env/:environment     @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByEnvironment(environment)
-GET     /frontend-route/:serviceName            @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByServiceName(serviceName)
-GET     /bobby/rules                            @uk.gov.hmrc.serviceconfigs.controller.BobbyController.allRules()
-GET     /alert-configs                          @uk.gov.hmrc.serviceconfigs.controller.AlertConfigController.getAlertConfigs()
-GET     /alert-configs/:serviceName             @uk.gov.hmrc.serviceconfigs.controller.AlertConfigController.getAlertConfigForService(serviceName: String)
+GET     /frontend-route/search                          @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByFrontendPath(frontendPath: String)
+GET     /frontend-route-by-env/:environment             @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByEnvironment(environment)
+GET     /frontend-route/:serviceName                    @uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByServiceName(serviceName)
+GET     /bobby/rules                                    @uk.gov.hmrc.serviceconfigs.controller.BobbyController.allRules()
+GET     /alert-configs                                  @uk.gov.hmrc.serviceconfigs.controller.AlertConfigController.getAlertConfigs()
+GET     /alert-configs/:serviceName                     @uk.gov.hmrc.serviceconfigs.controller.AlertConfigController.getAlertConfigForService(serviceName: String)
 
-GET     /deployment-config/:environment         @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForEnv(environment)
-GET     /deployment-config/:environment/:name   @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForService(environment, name)
+GET     /deployment-config/:environment                 @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForEnv(environment)
+GET     /deployment-config/:environment/:name           @uk.gov.hmrc.serviceconfigs.controller.DeploymentConfigController.deploymentConfigForService(environment, name)
 
-GET     /resource-usage/historic/:serviceName   @uk.gov.hmrc.serviceconfigs.controller.ResourceUsageController.historicResourceUsageForService(serviceName)
+GET     /resource-usage/services/:serviceName/snapshots @uk.gov.hmrc.serviceconfigs.controller.ResourceUsageController.resourceUsageSnapshotsForService(serviceName)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,12 +10,14 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-POST       /test-only/routes                 uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addRoutes
-DELETE     /test-only/routes                 uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.clearRoutes
-POST       /test-only/slugDependencyConfigs  uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addSlugDependencyConfigs()
-DELETE     /test-only/slugDependencyConfigs  uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugDependencyConfigs()
-POST       /test-only/sluginfos              uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addSlugs()
-DELETE     /test-only/sluginfos              uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugs()
-POST       /test-only/deploymentConfigs      uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addDeploymentConfigs()
-DELETE     /test-only/deploymentConfigs      uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteDeploymentConfigs()
-->         /                                 prod.Routes
+POST       /test-only/routes                    uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addRoutes
+DELETE     /test-only/routes                    uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.clearRoutes
+POST       /test-only/slugDependencyConfigs     uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addSlugDependencyConfigs()
+DELETE     /test-only/slugDependencyConfigs     uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugDependencyConfigs()
+POST       /test-only/sluginfos                 uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addSlugs()
+DELETE     /test-only/sluginfos                 uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteSlugs()
+POST       /test-only/deploymentConfigs         uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addDeploymentConfigs()
+DELETE     /test-only/deploymentConfigs         uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteDeploymentConfigs()
+POST       /test-only/deploymentConfigHistories uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.addDeploymentConfigHistories()
+DELETE     /test-only/deploymentConfigHistories uk.gov.hmrc.serviceconfigs.testonly.IntegrationTestController.deleteDeploymentConfigHistories()
+->         /                                    prod.Routes

--- a/test/uk/gov/hmrc/serviceconfigs/AlertConfigIntegrationSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/AlertConfigIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/JsonMarshallingSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/JsonMarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/NginxServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/WireMockEndPoints.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/WireMockEndPoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/config/NginxConfigSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/config/NginxConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/model/NginxConfigFileSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/model/NginxConfigFileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/model/ParserFrontendRoutesSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/model/ParserFrontendRoutesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/parser/ConfigParserSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/ConfigParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigIndexerSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigIndexerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParserSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxConfigParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxLexerSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxLexerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/parser/NginxTokenParserTest.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/parser/NginxTokenParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/AlertEnvironmentHandlerRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/AlertEnvironmentHandlerRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/AlertHashStringRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/AlertHashStringRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositoryS
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfig, DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepositorySpec._
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class DeploymentConfigSnapshotRepositorySpec extends AnyWordSpecLike
@@ -103,7 +103,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotA: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDate.of(2021, 1, 1),
+      LocalDateTime.of(2021, 1, 1, 0, 0, 0),
       "A",
       Environment.Production,
       Some(DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1)),
@@ -111,7 +111,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB1: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDate.of(2021, 1, 1),
+      LocalDateTime.of(2021, 1, 1, 0, 0, 0),
       "B",
       Environment.Production,
       Some(DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1)),
@@ -119,7 +119,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB2: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDate.of(2021, 1, 2),
+      LocalDateTime.of(2021, 1, 2, 0, 0, 0),
       "B",
       Environment.QA,
       Some(DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1)),
@@ -127,7 +127,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB3: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDate.of(2021, 1, 3),
+      LocalDateTime.of(2021, 1, 3, 0, 0, 0),
       "B",
       Environment.Staging,
       Some(DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1)),

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -104,24 +104,32 @@ object DeploymentConfigSnapshotRepositorySpec {
   val deploymentConfigSnapshotA: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
       LocalDate.of(2021, 1, 1),
-      DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1),
+      "A",
+      Environment.Production,
+      Some(DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1)),
     )
 
   val deploymentConfigSnapshotB1: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
       LocalDate.of(2021, 1, 1),
-      DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
+      "B",
+      Environment.Production,
+      Some(DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1)),
     )
 
   val deploymentConfigSnapshotB2: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
       LocalDate.of(2021, 1, 2),
-      DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
+      "B",
+      Environment.QA,
+      Some(DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1)),
     )
 
   val deploymentConfigSnapshotB3: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
       LocalDate.of(2021, 1, 3),
-      DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
+      "B",
+      Environment.Staging,
+      Some(DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1)),
     )
 }

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -103,45 +103,25 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotA: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      "A",
       LocalDate.of(2021, 1, 1),
-      List(
-        DeploymentConfig("A", None, Environment.QA, "public", "service", 5, 1),
-        DeploymentConfig("A", None, Environment.Staging, "public", "service", 5, 1),
-        DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1),
-      )
+      DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1),
     )
 
   val deploymentConfigSnapshotB1: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      "B",
       LocalDate.of(2021, 1, 1),
-      List(
-        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
-      )
+      DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
     )
 
   val deploymentConfigSnapshotB2: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      "B",
       LocalDate.of(2021, 1, 2),
-      List(
-        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
-      )
+      DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
     )
 
   val deploymentConfigSnapshotB3: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      "B",
       LocalDate.of(2021, 1, 3),
-      List(
-        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
-        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
-      )
+      DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
     )
 }

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositoryS
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfig, DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepositorySpec._
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class DeploymentConfigSnapshotRepositorySpec extends AnyWordSpecLike
@@ -103,7 +103,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotA: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      LocalDateTime.of(2021, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
       "A",
       Environment.Production,
       Some(DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1)),
@@ -111,7 +111,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB1: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      LocalDateTime.of(2021, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
       "B",
       Environment.Production,
       Some(DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1)),
@@ -119,7 +119,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB2: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDateTime.of(2021, 1, 2, 0, 0, 0),
+      LocalDateTime.of(2021, 1, 2, 0, 0, 0).toInstant(ZoneOffset.UTC),
       "B",
       Environment.QA,
       Some(DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1)),
@@ -127,7 +127,7 @@ object DeploymentConfigSnapshotRepositorySpec {
 
   val deploymentConfigSnapshotB3: DeploymentConfigSnapshot =
     DeploymentConfigSnapshot(
-      LocalDateTime.of(2021, 1, 3, 0, 0, 0),
+      LocalDateTime.of(2021, 1, 3, 0, 0, 0).toInstant(ZoneOffset.UTC),
       "B",
       Environment.Staging,
       Some(DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1)),

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/DeploymentConfigSnapshotRepositorySpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.persistence
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositorySupport}
+import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfig, DeploymentConfigSnapshot, Environment}
+import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepositorySpec._
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DeploymentConfigSnapshotRepositorySpec extends AnyWordSpecLike
+  with Matchers
+  with PlayMongoRepositorySupport[DeploymentConfigSnapshot]
+  with CleanMongoCollectionSupport {
+
+  override lazy val repository =
+    new DeploymentConfigSnapshotRepository(mongoComponent)
+
+  "DeploymentConfigSnapshotRepository" should {
+
+    "Persist and retrieve `DeploymentConfigSnapshot`s" in {
+
+      val before =
+        repository.snapshotsForService("A").futureValue
+
+      repository.add(deploymentConfigSnapshotA).futureValue
+
+      val after =
+        repository.snapshotsForService("A").futureValue
+
+      before shouldBe empty
+      after shouldBe List(deploymentConfigSnapshotA)
+    }
+
+    "Retrieve snapshots by service name" in {
+
+      repository.add(deploymentConfigSnapshotA).futureValue
+      repository.add(deploymentConfigSnapshotB1).futureValue
+
+      val snapshots =
+        repository.snapshotsForService("A").futureValue
+
+      snapshots shouldBe List(deploymentConfigSnapshotA)
+    }
+
+    "Retrieve snapshots sorted by date, ascending" in {
+
+      repository.add(deploymentConfigSnapshotB2).futureValue
+      repository.add(deploymentConfigSnapshotB1).futureValue
+      repository.add(deploymentConfigSnapshotB3).futureValue
+
+      val snapshots =
+        repository.snapshotsForService("B").futureValue
+
+      snapshots shouldBe List(
+        deploymentConfigSnapshotB1,
+        deploymentConfigSnapshotB2,
+        deploymentConfigSnapshotB3
+      )
+    }
+
+    "Delete all documents in the collection" in  {
+
+      repository.add(deploymentConfigSnapshotA).futureValue
+      repository.add(deploymentConfigSnapshotB1).futureValue
+      repository.add(deploymentConfigSnapshotB2).futureValue
+      repository.add(deploymentConfigSnapshotB3).futureValue
+
+      val before =
+        repository.snapshotsForService("A").futureValue ++
+          repository.snapshotsForService("B").futureValue
+
+      repository.deleteAll().futureValue
+
+      val after =
+        repository.snapshotsForService("A").futureValue
+
+      before.size shouldBe 4
+      after shouldBe empty
+    }
+  }
+
+}
+
+object DeploymentConfigSnapshotRepositorySpec {
+
+  val deploymentConfigSnapshotA: DeploymentConfigSnapshot =
+    DeploymentConfigSnapshot(
+      "A",
+      LocalDate.of(2021, 1, 1),
+      List(
+        DeploymentConfig("A", None, Environment.QA, "public", "service", 5, 1),
+        DeploymentConfig("A", None, Environment.Staging, "public", "service", 5, 1),
+        DeploymentConfig("A", None, Environment.Production, "public", "service", 5, 1),
+      )
+    )
+
+  val deploymentConfigSnapshotB1: DeploymentConfigSnapshot =
+    DeploymentConfigSnapshot(
+      "B",
+      LocalDate.of(2021, 1, 1),
+      List(
+        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
+      )
+    )
+
+  val deploymentConfigSnapshotB2: DeploymentConfigSnapshot =
+    DeploymentConfigSnapshot(
+      "B",
+      LocalDate.of(2021, 1, 2),
+      List(
+        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
+      )
+    )
+
+  val deploymentConfigSnapshotB3: DeploymentConfigSnapshot =
+    DeploymentConfigSnapshot(
+      "B",
+      LocalDate.of(2021, 1, 3),
+      List(
+        DeploymentConfig("B", None, Environment.QA, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Staging, "public", "service", 5, 1),
+        DeploymentConfig("B", None, Environment.Production, "public", "service", 5, 1),
+      )
+    )
+}

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepositoryMongoSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepositoryMongoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/FrontendRouteRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/SlugVersionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/SlugVersionRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/YamlToBsonSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/YamlToBsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/service/AlertConfigSchedulerServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/AlertConfigSchedulerServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/service/DeploymentConfigServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/DeploymentConfigServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfig, DeploymentConfigSnapshot, Environment}
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -36,13 +36,13 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
       val snapshots =
         Seq(
           DeploymentConfigSnapshot(
-            LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
             "name",
             Environment.Staging,
             Some(DeploymentConfig("name", None, Environment.Staging, "public", "service", 5, 1)),
           ),
           DeploymentConfigSnapshot(
-            LocalDateTime.of(2021, 1, 1, 0, 0, 1),
+            LocalDateTime.of(2021, 1, 1, 0, 0, 1).toInstant(ZoneOffset.UTC),
             "name",
             Environment.Production,
             None
@@ -55,14 +55,14 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
       val expectedHistoricResourceUsages =
         Seq(
           ResourceUsage(
-            LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
             "name",
             Environment.Staging,
             5,
             1
           ),
           ResourceUsage(
-            LocalDateTime.of(2021, 1, 1, 0, 0, 1),
+            LocalDateTime.of(2021, 1, 1, 0, 0, 1).toInstant(ZoneOffset.UTC),
             "name",
             Environment.Production,
             0,

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -1,0 +1,106 @@
+package uk.gov.hmrc.serviceconfigs.service
+
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.serviceconfigs.model.{DeploymentConfig, DeploymentConfigSnapshot, Environment}
+import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
+
+import java.time.LocalDateTime
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar {
+
+  "Service" should {
+
+    "Map `DeploymentConfigSnapshot`s to `ResourceUsage`" in {
+
+      val snapshots =
+        Seq(
+          DeploymentConfigSnapshot(
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            "name",
+            Environment.Staging,
+            Some(DeploymentConfig("name", None, Environment.Staging, "public", "service", 5, 1)),
+          ),
+          DeploymentConfigSnapshot(
+            LocalDateTime.of(2021, 1, 1, 0, 0, 1),
+            "name",
+            Environment.Production,
+            None
+          )
+        )
+
+      val resourceUsageService =
+        new ResourceUsageService(stubDeploymentConfigSnapshotRepository("name", snapshots))
+
+      val expectedResourceUsages =
+        Seq(
+          ResourceUsage(
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            "name",
+            Environment.Staging,
+            5,
+            1
+          ),
+          ResourceUsage(
+            LocalDateTime.of(2021, 1, 1, 0, 0, 1),
+            "name",
+            Environment.Production,
+            0,
+            0
+          )
+        )
+
+      resourceUsageService.resourceUsageForService("name").futureValue shouldBe expectedResourceUsages
+    }
+
+    "Provide a cost estimation based on resource usage" in {
+      ResourceUsage(
+        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+        "name",
+        Environment.Staging,
+        slots = 0,
+        instances = 1
+      ).estimatedYearlyCostUsd shouldBe 120.0
+
+      ResourceUsage(
+        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+        "name",
+        Environment.Staging,
+        slots = 1,
+        instances = 1
+      ).estimatedYearlyCostUsd shouldBe 120.0
+
+      ResourceUsage(
+        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+        "name",
+        Environment.Staging,
+        slots = 1,
+        instances = 0
+      ).estimatedYearlyCostUsd shouldBe 0
+
+      ResourceUsage(
+        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+        "name",
+        Environment.Staging,
+        slots = 50,
+        instances = 10
+      ).estimatedYearlyCostUsd shouldBe 1200.0
+    }
+  }
+
+  private def stubDeploymentConfigSnapshotRepository(
+    name: String,
+    snapshots: Seq[DeploymentConfigSnapshot]
+  ): DeploymentConfigSnapshotRepository = {
+    val repository =
+      mock[DeploymentConfigSnapshotRepository]
+
+    when(repository.snapshotsForService(name)).thenReturn(Future.successful(snapshots))
+
+    repository
+  }
+}

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.serviceconfigs.service
 
 import org.mockito.scalatest.MockitoSugar

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -52,7 +52,7 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
       val resourceUsageService =
         new ResourceUsageService(stubDeploymentConfigSnapshotRepository("name", snapshots))
 
-      val expectedResourceUsages =
+      val expectedHistoricResourceUsages =
         Seq(
           ResourceUsage(
             LocalDateTime.of(2021, 1, 1, 0, 0, 0),
@@ -70,7 +70,8 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
           )
         )
 
-      resourceUsageService.resourceUsageForService("name").futureValue shouldBe expectedResourceUsages
+      resourceUsageService.historicResourceUsageForService("name").futureValue shouldBe
+        expectedHistoricResourceUsages
     }
   }
 

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -70,7 +70,7 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
           )
         )
 
-      resourceUsageService.historicResourceUsageForService("name").futureValue shouldBe
+      resourceUsageService.resourceUsageSnapshotsForService("name").futureValue shouldBe
         expectedHistoricResourceUsages
     }
   }

--- a/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/ResourceUsageServiceSpec.scala
@@ -56,40 +56,6 @@ class ResourceUsageServiceSpec extends AnyWordSpec with Matchers with ScalaFutur
 
       resourceUsageService.resourceUsageForService("name").futureValue shouldBe expectedResourceUsages
     }
-
-    "Provide a cost estimation based on resource usage" in {
-      ResourceUsage(
-        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-        "name",
-        Environment.Staging,
-        slots = 0,
-        instances = 1
-      ).estimatedYearlyCostUsd shouldBe 120.0
-
-      ResourceUsage(
-        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-        "name",
-        Environment.Staging,
-        slots = 1,
-        instances = 1
-      ).estimatedYearlyCostUsd shouldBe 120.0
-
-      ResourceUsage(
-        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-        "name",
-        Environment.Staging,
-        slots = 1,
-        instances = 0
-      ).estimatedYearlyCostUsd shouldBe 0
-
-      ResourceUsage(
-        LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-        "name",
-        Environment.Staging,
-        slots = 50,
-        instances = 10
-      ).estimatedYearlyCostUsd shouldBe 1200.0
-    }
   }
 
   private def stubDeploymentConfigSnapshotRepository(

--- a/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/SlugConfigurationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/serviceconfigs/service/SqsMessageHandlingSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/service/SqsMessageHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR introduces the concept of a `DeploymentConfigSnapshot`, a point-in-time snapshot of a service's `DeploymentConfig`, across all environments in which it was deployed.

Additionally, `ResourceUsage` is introduced as a related but separate concept that will support the work in the Catalogue to graph historic cost estimations for services.