### PR TITLE
Bdog 2564

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/controller/ConfigController.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/controller/ConfigController.scala
@@ -76,4 +76,11 @@ class ConfigController @Inject()(
       Ok(Json.toJson(k))
     }
   }
+  @ApiOperation(
+    value = "Retrieves all config keys."
+  )
+  val configKeys: Action[AnyContent] = Action.async {
+    configService.findConfigKeys()
+      .map(res => Ok(Json.toJson(res)))
+  }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/AppliedConfigRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/AppliedConfigRepository.scala
@@ -83,6 +83,11 @@ class AppliedConfigRepository @Inject()(
       )
     ).toFuture()
 
+  def findConfigKeys(): Future[Seq[String]] =
+    collection.distinct[String]("key")
+      .toFuture()
+      .map(_.sorted)
+
   def delete(environment: Environment, serviceName: String): Future[Unit] =
     collection.deleteMany(
       Filters.and(

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/ConfigScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/ConfigScheduler.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.serviceconfigs.scheduler
 import akka.actor.ActorSystem
 import play.api.Logging
 import play.api.inject.ApplicationLifecycle
-import uk.gov.hmrc.mongo.lock.{MongoLockRepository, TimePeriodLockService}
+import uk.gov.hmrc.mongo.TimestampSupport
 import uk.gov.hmrc.serviceconfigs.config.SchedulerConfigs
 import uk.gov.hmrc.serviceconfigs.persistence.DeploymentConfigSnapshotRepository
 import uk.gov.hmrc.serviceconfigs.service.AlertConfigService
@@ -34,7 +34,8 @@ class ConfigScheduler @Inject()(
   schedulerConfigs                  : SchedulerConfigs,
   mongoLockRepository               : MongoLockRepository,
   alertConfigService                : AlertConfigService,
-  deploymentConfigSnapshotRepository: DeploymentConfigSnapshotRepository
+  deploymentConfigSnapshotRepository: DeploymentConfigSnapshotRepository,
+  timestampSupport                  : TimestampSupport
 )(implicit
   actorSystem         : ActorSystem,
   applicationLifecycle: ApplicationLifecycle,
@@ -44,7 +45,7 @@ class ConfigScheduler @Inject()(
   scheduleWithTimePeriodLock(
     label           = "ConfigScheduler",
     schedulerConfig = schedulerConfigs.configScheduler,
-    lock            = TimePeriodLockService(mongoLockRepository, "config-scheduler", schedulerConfigs.configScheduler.interval.minus(1.minutes))
+    lock            = TimePeriodLockService(mongoLockRepository, "config-scheduler", timestampSupport, schedulerConfigs.configScheduler.interval.plus(1.minutes))
   ) {
     logger.info("Updating config")
     for {

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/MissedWebhookEventsScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/MissedWebhookEventsScheduler.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.serviceconfigs.scheduler
 import akka.actor.ActorSystem
 import play.api.Logging
 import play.api.inject.ApplicationLifecycle
-import uk.gov.hmrc.mongo.lock.{MongoLockRepository, TimePeriodLockService}
+import uk.gov.hmrc.mongo.TimestampSupport
 import uk.gov.hmrc.serviceconfigs.config.SchedulerConfigs
 import uk.gov.hmrc.serviceconfigs.model.Environment
 import uk.gov.hmrc.serviceconfigs.service._
@@ -40,6 +40,7 @@ class MissedWebhookEventsScheduler @Inject()(
   nginxService            : NginxService,
   routesConfigService     : RoutesConfigService,
   outagePageService       : OutagePageService,
+  timestampSupport        : TimestampSupport
 )(implicit
   actorSystem         : ActorSystem,
   applicationLifecycle: ApplicationLifecycle,
@@ -49,7 +50,7 @@ class MissedWebhookEventsScheduler @Inject()(
   scheduleWithTimePeriodLock(
     label           = "MissedWebhookEventsScheduler",
     schedulerConfig = schedulerConfigs.missedWebhookEventsScheduler,
-    lock            = TimePeriodLockService(mongoLockRepository, "missed-webhook-events", schedulerConfigs.missedWebhookEventsScheduler.interval.minus(1.minutes))
+    lock            = TimePeriodLockService(mongoLockRepository, "missed-webhook-events", timestampSupport, schedulerConfigs.missedWebhookEventsScheduler.interval.plus(1.minutes))
   ) {
     logger.info("Updating incase of missed webhook event")
     for {

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/MongoLockRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/MongoLockRepository.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.scheduler
+
+import java.time.{Duration => JavaDuration}
+
+import uk.gov.hmrc.mongo.lock.Lock
+import com.google.inject.ImplementedBy
+import javax.inject.{Inject, Singleton}
+import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model.Updates
+import play.api.Logger
+import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
+import uk.gov.hmrc.mongo.MongoUtils.DuplicateKey
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[MongoLockRepository])
+trait LockRepository {
+  def takeLock(lockId: String, owner: String, ttl: Duration): Future[Option[Lock]]
+
+  def releaseLock(lockId: String, owner: String): Future[Unit]
+
+  def refreshExpiry(lockId: String, owner: String, ttl: Duration): Future[Boolean]
+
+  def isLocked(lockId: String, owner: String): Future[Boolean]
+}
+
+@Singleton
+class MongoLockRepository @Inject()(
+  mongoComponent  : MongoComponent,
+  timestampSupport: TimestampSupport
+)(implicit
+  ec: ExecutionContext
+) extends PlayMongoRepository[Lock](
+  mongoComponent,
+  collectionName = "locks",
+  domainFormat   = Lock.format,
+  indexes        = Seq.empty
+) with LockRepository {
+
+  private val logger = Logger(getClass)
+
+  override lazy val requiresTtlIndex = false // each lock defines it's own expiry, so doesn't rely on ttl indexes
+
+  override def takeLock(lockId: String, owner: String, ttl: Duration): Future[Option[Lock]] = {
+    val now        = timestampSupport.timestamp()
+    val expiryTime = now.plus(JavaDuration.ofMillis(ttl.toMillis))
+
+    (for {
+      deleteResult <- collection
+                        .deleteOne(
+                           and(
+                             equal(Lock.id, lockId),
+                             lte(Lock.expiryTime, now)
+                           )
+                         )
+                        .toFuture()
+      _            =  if (deleteResult.getDeletedCount != 0) {
+                        logger.info(s"Removed ${deleteResult.getDeletedCount} expired locks for $lockId")
+                      }
+      lock         =  Lock(
+                        id          = lockId,
+                        owner       = owner,
+                        timeCreated = now,
+                        expiryTime  = expiryTime
+                      )
+      _            <- collection
+                        .insertOne(lock)
+                        .toFuture()
+      _            =  logger.debug(s"Took lock '$lockId' for '$owner' at $now. Expires at: $expiryTime")
+     } yield Some(lock)
+    ).recover {
+      case DuplicateKey(e) =>
+        logger.debug(s"Unable to take lock '$lockId' for '$owner'")
+        None
+    }
+  }
+
+  override def releaseLock(lockId: String, owner: String): Future[Unit] = {
+    logger.debug(s"Releasing lock '$lockId' for '$owner'")
+    collection
+      .deleteOne(
+         and(
+           equal(Lock.id, lockId),
+           equal(Lock.owner, owner)
+         )
+       )
+      .toFuture()
+      .map(_ => ())
+  }
+
+  override def refreshExpiry(lockId: String, owner: String, ttl: Duration): Future[Boolean] = {
+    val now        = timestampSupport.timestamp()
+    val expiryTime = now.plus(JavaDuration.ofMillis(ttl.toMillis))
+
+    // Use findOneAndUpdate to ensure the read and the write are performed as one atomic operation
+    collection
+      .findOneAndUpdate(
+        filter = and(
+                   equal(Lock.id, lockId),
+                   equal(Lock.owner, owner),
+                   gte(Lock.expiryTime, now)
+                 ),
+        update = Updates.set(Lock.expiryTime, expiryTime)
+      )
+      .toFutureOption()
+      .map {
+        case Some(_) =>
+          logger.debug(s"Renewed lock '$lockId' for '$owner' at $now.  Expires at: $expiryTime")
+          true
+        case None =>
+          logger.debug(s"Could not renew lock '$lockId' for '$owner' that does not exist or has expired")
+          false
+      }
+      .recover {
+        case DuplicateKey(e) =>
+          logger.debug(s"Unable to renew lock '$lockId' for '$owner'")
+          false
+      }
+  }
+
+  override def isLocked(lockId: String, owner: String): Future[Boolean] =
+    collection
+      .find(
+        and(
+          equal(Lock.id, lockId),
+          equal(Lock.owner, owner),
+          gt(Lock.expiryTime, timestampSupport.timestamp())
+        )
+       )
+      .toFuture()
+      .map(_.nonEmpty)
+}

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/SchedulerUtils.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/SchedulerUtils.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.serviceconfigs.scheduler
 import akka.actor.ActorSystem
 import play.api.Logging
 import play.api.inject.ApplicationLifecycle
-import uk.gov.hmrc.mongo.lock.TimePeriodLockService
 import uk.gov.hmrc.serviceconfigs.config.SchedulerConfig
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/ServiceRelationshipScheduler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/ServiceRelationshipScheduler.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.serviceconfigs.scheduler
 import akka.actor.ActorSystem
 import play.api.inject.ApplicationLifecycle
 import play.api.Logging
-import uk.gov.hmrc.mongo.lock.{MongoLockRepository, TimePeriodLockService}
+import uk.gov.hmrc.mongo.TimestampSupport
 import uk.gov.hmrc.serviceconfigs.config.SchedulerConfigs
 import uk.gov.hmrc.serviceconfigs.service._
 
@@ -31,7 +31,8 @@ import scala.concurrent.ExecutionContext
 class ServiceRelationshipScheduler @Inject()(
   schedulerConfigs                  : SchedulerConfigs,
   mongoLockRepository               : MongoLockRepository,
-  serviceRelationshipService        : ServiceRelationshipService
+  serviceRelationshipService        : ServiceRelationshipService,
+  timestampSupport                  : TimestampSupport
 )(implicit
   actorSystem         : ActorSystem,
   applicationLifecycle: ApplicationLifecycle,
@@ -41,7 +42,7 @@ class ServiceRelationshipScheduler @Inject()(
   scheduleWithTimePeriodLock(
     label           = "ServiceRelationshipScheduler",
     schedulerConfig = schedulerConfigs.serviceRelationshipScheduler,
-    lock            = TimePeriodLockService(mongoLockRepository, "service-relationship-scheduler", schedulerConfigs.serviceRelationshipScheduler.interval.minus(1.minutes))
+    lock            = TimePeriodLockService(mongoLockRepository, "service-relationship-scheduler", timestampSupport, schedulerConfigs.serviceRelationshipScheduler.interval.plus(1.minutes))
   ) {
     logger.info("Updating service relationships")
     for {

--- a/app/uk/gov/hmrc/serviceconfigs/scheduler/TimePeriodLockService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/scheduler/TimePeriodLockService.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.scheduler
+
+import uk.gov.hmrc.mongo.TimestampSupport
+
+import java.time.{Duration => JavaDuration}
+import java.util.UUID
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+
+/** For locking for a give time period (i.e. stop other instances executing the task until it stops renewing the lock).
+  * The lock will be held on to when the task has finished, until it expires.
+  *
+  * This varies from the version currently available in hmrc-mongo since it will not start a new task if there is already
+  * one currently running on the instance. Instead, it will refresh the lock if it is still required, and not start a new run.
+  *
+  * It will release the lock if there is a failure, or the scheduler finishes normally and took longer than expected to run.
+  *
+  * It is required to defined the expected frequency as the ttl, and run the scheduler slightly more frequent than this to
+  * check if the ttl needs refreshing.
+  */
+trait TimePeriodLockService {
+
+  val lockRepository: LockRepository
+  val lockId: String
+  val timestampSupport: TimestampSupport
+  val ttl: Duration
+
+  private val ownerId = UUID.randomUUID().toString
+
+  /** Runs `body` if a lock can be taken or if the existing lock is owned by this service instance.
+    * The lock is not released at the end of but task (unless it ends in failure), but is held onto until it expires.
+    */
+  def withRenewedLock[T](body: => Future[T])(implicit ec: ExecutionContext): Future[Option[T]] =
+      (for {
+         refreshed <- lockRepository.refreshExpiry(lockId, ownerId, ttl) // ensure our instance continues to have a valid lock in place
+         acquired  <- if (!refreshed)
+                        lockRepository.takeLock(lockId, ownerId, ttl)
+                      else
+                        Future.successful(None)
+         result    <- acquired match {
+                        case Some(lock) =>
+                          // we only start the body if we've acquired a new lock. If we have refreshed, then we are currently running, and we don't want multiple runs in parallel
+                          for {
+                            res <- body
+                            _   <- if (timestampSupport.timestamp().toEpochMilli > lock.timeCreated.plus(JavaDuration.ofMillis(ttl.toMillis)).toEpochMilli)
+                                     lockRepository.releaseLock(lockId, ownerId)
+                                   else
+                                     // don't release the lock, let it timeout, so nothing else starts prematurely
+                                     Future.unit
+                          } yield Some(res)
+                        case None =>
+                          Future.successful(None)
+                      }
+       } yield result
+      ).recoverWith {
+        case ex => // if we fail with an error, release the lock so another run can start on the earliest opportunity
+                   lockRepository.releaseLock(lockId, ownerId).flatMap(_ => Future.failed(ex))
+      }
+}
+
+object TimePeriodLockService {
+
+  def apply(lockRepository: LockRepository, lockId: String, timestampSupport: TimestampSupport, ttl: Duration): TimePeriodLockService = {
+    val (lockRepository1, lockId1, timestampSupport1, ttl1) = (lockRepository, lockId, timestampSupport, ttl)
+    new TimePeriodLockService {
+      override val lockRepository  : LockRepository   = lockRepository1
+      override val lockId          : String           = lockId1
+      override val timestampSupport: TimestampSupport = timestampSupport1
+      override val ttl             : Duration         = ttl1
+    }
+  }
+}

--- a/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ConfigService.scala
@@ -269,6 +269,9 @@ class ConfigService @Inject()(
       environment
     )
 
+  def findConfigKeys(): Future[Seq[String]] =
+    appliedConfigRepository.findConfigKeys()
+
   // TODO consideration for deprecated naming? e.g. application.secret -> play.crypto.secret -> play.http.secret.key
   def configByKey(serviceName: String, latest: Boolean)(implicit hc: HeaderCarrier): Future[ConfigByKey] =
     ConfigEnvironment.values.toList

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,6 +3,7 @@
 GET     /config-by-env/:serviceName                     uk.gov.hmrc.serviceconfigs.controller.ConfigController.serviceConfig(serviceName, latest: Boolean ?= true)
 GET     /config-by-key/:serviceName                     uk.gov.hmrc.serviceconfigs.controller.ConfigController.configByKey(serviceName, latest: Boolean ?= true)
 GET     /search                                         uk.gov.hmrc.serviceconfigs.controller.ConfigController.search(key, environment: Seq[Environment] ?= Seq.empty)
+GET     /configkeys                                     uk.gov.hmrc.serviceconfigs.controller.ConfigController.configKeys
 
 GET     /frontend-route/search                          uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByFrontendPath(frontendPath: String)
 GET     /frontend-route-by-env/:environment             uk.gov.hmrc.serviceconfigs.controller.NginxController.searchByEnvironment(environment)

--- a/test/uk/gov/hmrc/serviceconfigs/persistence/AppliedConfigRepositorySpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/persistence/AppliedConfigRepositorySpec.scala
@@ -152,4 +152,14 @@ class AppliedConfigRepositorySpec
       repository.find("\"k\"", environment = Seq(Environment.Development)).futureValue should contain theSameElementsAs Seq.empty
     }
   }
+
+  "return config keys" in {
+    val serviceName1 = "serviceName1"
+    repository.put(Environment.Development, serviceName1, Map("k1" -> "v1", "k2" -> "v2")).futureValue
+    repository.put(Environment.QA         , serviceName1, Map("k1" -> "v1", "k4" -> "v4")).futureValue
+    val serviceName2 = "serviceName2"
+    repository.put(Environment.Development, serviceName2, Map("k1" -> "v1", "k3" -> "v3")).futureValue
+
+    repository.findConfigKeys().futureValue shouldBe Seq("k1", "k2", "k3", "k4")
+  }
 }

--- a/test/uk/gov/hmrc/serviceconfigs/scheduler/TimePeriodLockServiceSpec.scala
+++ b/test/uk/gov/hmrc/serviceconfigs/scheduler/TimePeriodLockServiceSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.serviceconfigs.scheduler
+
+import org.mongodb.scala.model.Filters
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.mongo.CurrentTimestampSupport
+import uk.gov.hmrc.mongo.lock.Lock
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.{Duration, DurationInt}
+
+class TimePeriodLockServiceSpec
+  extends AnyWordSpecLike
+     with Matchers
+     with DefaultPlayMongoRepositorySupport[Lock]
+     with OptionValues {
+
+  "withRenewedLock" should {
+    "execute the body if no previous lock is set" in {
+      var counter = 0
+      lockService.withRenewedLock {
+        Future.successful(counter += 1)
+      }.futureValue
+      counter shouldBe 1
+    }
+
+    "leave the lock to expire" in {
+      lockService.withRenewedLock {
+        Future.unit
+      }.futureValue
+      val lock = repository.collection.find[Lock](Filters.equal(Lock.id, lockId)).headOption().futureValue
+      lock shouldBe defined
+    }
+
+    "not execute the body if the lock for same serverId exists" in {
+      // TODO but confirm it has refreshed
+      val counter = new AtomicInteger(0)
+      lockService.withRenewedLock {
+        Future.successful(counter.incrementAndGet())
+      }.futureValue
+
+      val lock = repository.collection.find[Lock](Filters.equal(Lock.id, lockId)).headOption().futureValue
+
+      lockService.withRenewedLock {
+        Future.successful(counter.incrementAndGet())
+      }.futureValue
+
+      counter.get() shouldBe 1
+
+      // expiryTime should have been increased
+      val lock2 = repository.collection.find[Lock](Filters.equal(Lock.id, lockId)).headOption().futureValue
+      lock2.value.expiryTime should not be lock.value.expiryTime
+    }
+
+    "not execute the body and exit if the lock for another serverId exists" in {
+      val counter = new AtomicInteger(0)
+      TimePeriodLockService(repository, lockId, timestampSupport, ttl)
+        .withRenewedLock {
+          Future.successful(counter.incrementAndGet())
+        }
+        .futureValue
+
+      lockService.withRenewedLock {
+        Future.successful(counter.incrementAndGet())
+      }.futureValue
+
+      counter.get() shouldBe 1
+    }
+
+    "execute the body if run after the ttl time has expired" in {
+      val counter = new AtomicInteger(0)
+      lockService.withRenewedLock {
+        Future.successful(counter.incrementAndGet())
+      }.futureValue
+
+      Thread.sleep(1000 + 1)
+
+      lockService.withRenewedLock {
+        Future.successful(counter.incrementAndGet())
+      }.futureValue
+
+      counter.get() shouldBe 2
+    }
+
+    "release the lock if body fails" in {
+      val e = new RuntimeException("boom")
+      lockService.withRenewedLock {
+        Future.failed(e)
+      }.failed.futureValue shouldBe e
+      val lock = repository.collection.find[Lock](Filters.equal(Lock.id, lockId)).headOption().futureValue
+      lock should not be defined
+    }
+
+    "release the lock if body takes longer than expected to run" in {
+      lockService.withRenewedLock {
+        Thread.sleep(1000 + 1)
+        Future.unit
+      }.futureValue
+      val lock = repository.collection.find[Lock](Filters.equal(Lock.id, lockId)).headOption().futureValue
+      lock should not be defined
+    }
+  }
+
+  private val lockId        = "lockId"
+  private val ttl: Duration = 1000.millis
+  private val timestampSupport = new CurrentTimestampSupport
+
+  override protected val repository = new MongoLockRepository(mongoComponent, timestampSupport)
+  private val lockService           = TimePeriodLockService(repository, lockId, timestampSupport, ttl)
+}


### PR DESCRIPTION
- Adds initial configKeys endpoint
- Inlines `TimePeriodLockService` from `hmrc-mongo` to address tasks running longer than expired overlapping on the same instance