### PR TITLE
BDOG-2686 Don't update deployedConfig when the current deployedConfig…

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/Module.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/Module.scala
@@ -21,6 +21,8 @@ import uk.gov.hmrc.serviceconfigs.parser.{FrontendRouteParser, NginxConfigParser
 import uk.gov.hmrc.serviceconfigs.notification.{DeadLetterHandler, DeploymentHandler, SlugConfigUpdateHandler}
 import uk.gov.hmrc.serviceconfigs.scheduler.{ConfigScheduler, MissedWebhookEventsScheduler, ServiceRelationshipScheduler, SlugMetadataUpdateScheduler}
 
+import java.time.Clock
+
 class Module extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[SlugConfigUpdateHandler     ]).asEagerSingleton()
@@ -31,5 +33,6 @@ class Module extends AbstractModule {
     bind(classOf[SlugMetadataUpdateScheduler ]).asEagerSingleton()
     bind(classOf[ServiceRelationshipScheduler]).asEagerSingleton()
     bind(classOf[FrontendRouteParser         ]).to(classOf[NginxConfigParser]).asEagerSingleton()
+    bind(classOf[Clock]).toInstance(Clock.systemUTC())
   }
 }

--- a/app/uk/gov/hmrc/serviceconfigs/notification/DeploymentHandler.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/notification/DeploymentHandler.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.serviceconfigs.connector.ReleasesApiConnector
 import uk.gov.hmrc.serviceconfigs.model.{CommitId, Environment, FileName, RepoName, ServiceName, Version}
 import uk.gov.hmrc.serviceconfigs.service.SlugInfoService
 
-import java.time.Instant
+import java.time.{Instant, Clock}
 import scala.collection.immutable.TreeMap
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -45,7 +45,7 @@ import scala.util.{Failure, Try}
 class DeploymentHandler @Inject()(
   config         : ArtefactReceivingConfig,
   slugInfoService: SlugInfoService,
-  clock          : java.time.Clock
+  clock          : Clock
   )(implicit
   actorSystem : ActorSystem,
   materializer: Materializer,

--- a/app/uk/gov/hmrc/serviceconfigs/persistence/DeployedConfigRepository.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/persistence/DeployedConfigRepository.scala
@@ -111,6 +111,6 @@ object DeployedConfigRepository {
     ~ (__ \ "appConfigCommon").formatNullable[String]
     ~ (__ \ "appConfigEnv"   ).formatNullable[String]
     ~ (__ \ "lastUpdated"    ).format[Instant]
-      )(DeployedConfig. apply, unlift(DeployedConfig.unapply))
+      )(DeployedConfig.apply, unlift(DeployedConfig.unapply))
   }
 }


### PR DESCRIPTION
… lastUpdated field is more recent than the dataTimestamp

It was observed that if a deployment event is triggered after the scheduler has begun. The scheduler (which now has stale data relative to the new deployment event), will overwrite the deployedConfig update triggered by the deployment event. This is because the configIDs were different.

We now capture the timestamp when a deployment event is triggered, or when the scheduler begins, and pass this to our updateDeployment method. Even if the configIDs differ, it will only update the deployedConfig if the current deployedConfig lastUpdated field is prior to the timestamp.