### PR TITLE
BDOG-2791 Preserve logger names when loading from System.properties

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.13.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.20")


### PR DESCRIPTION
Without this, `logger.uk.gov:WARN` and `logger.uk.gov.hmrc:DEBUG` and reduced to `logger { uk { gov { hmrc: DEBUG } } }` rather than `logger { "uk.gov": WARN, "uk.gov.hmrc": DEBUG } } }` which is how they are loaded by the LoggingModule