### PR TITLE
BDOG-3368 Fix service-manager-config detection

### DIFF
--- a/app/uk/gov/hmrc/serviceconfigs/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/connector/ConfigConnector.scala
@@ -51,13 +51,6 @@ class ConfigConnector @Inject()(
   def serviceManagerConfig()(using hc: HeaderCarrier): Future[Option[String]] =
     doCall(url"${githubConfig.githubRawUrl}/hmrc/service-manager-config/main/services.json")
 
-  def serviceMappings()(using hc: HeaderCarrier): Future[Map[String, String]] =
-    httpClientV2
-      .get(url"${githubConfig.githubRawUrl}/hmrc/service-manager-config/main/service_mappings.json")
-      .setHeader(("Authorization", s"token ${githubConfig.githubToken}"))
-      .withProxy
-      .execute[Map[String, String]]
-  
   private def doCall(url: URL)(using hc: HeaderCarrier) =
     httpClientV2
       .get(url)

--- a/app/uk/gov/hmrc/serviceconfigs/service/ServiceManagerConfigService.scala
+++ b/app/uk/gov/hmrc/serviceconfigs/service/ServiceManagerConfigService.scala
@@ -40,16 +40,16 @@ class ServiceManagerConfigService @Inject()(
     for
       _          <- Future.successful(logger.info(s"Updating Service Manager Config ..."))
       smConfig   <- configConnector.serviceManagerConfig().map(_.getOrElse("").linesIterator.zipWithIndex.toList)
-      smMappings <- configConnector.serviceMappings()
       repos      <- ( teamsAndRepositoriesConnector.getRepos(repoType = Some("Service"))
                     , teamsAndRepositoriesConnector.getDeletedRepos(repoType = Some("Service"))
                     ).mapN(_ ++ _)
       items      =  repos.flatMap: repo =>
                       smConfig
-                        .find:
-                          case (line, _) => line.contains(smMappings.get(repo.repoName.asString).fold(s"\"${repo.repoName.asString.toUpperCase.replaceAll("-", "_")}\"")(n => s"\"$n\""))
-                        .map:
-                          case (_, idx ) => ServiceManagerConfigRepository.ServiceManagerConfig(ServiceName(repo.repoName.asString), s"https://github.com/hmrc/service-manager-config/blob/main/services.json#L${idx + 1}")
+                        .find: (line, _) =>
+                          line.contains("\"repo\"") && line.contains(s"git@github.com:hmrc/${repo.repoName.asString}.git")
+                            || line.contains("\"artifact\"") && line.contains(s"\"${repo.repoName.asString}_")
+                        .map: (_, idx ) =>
+                          ServiceManagerConfigRepository.ServiceManagerConfig(ServiceName(repo.repoName.asString), s"https://github.com/hmrc/service-manager-config/blob/main/services.json#L${idx + 1}")
       _          =  logger.info(s"Inserting ${items.size} Service Manager Config into mongo")
       count      <- serviceManagerConfigRepository.putAll(items)
       _          =  logger.info(s"Inserted $count Service Manager Config into mongo")

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val microservice = Project("service-configs", file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
-    scalaVersion        :=  "3.3.4",
+    scalaVersion        :=  "3.3.5",
     majorVersion        :=  1,
     playDefaultPort     :=  8460,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,16 +3,16 @@ import sbt._
 
 object AppDependencies {
 
-  val hmrcMongoVersion     = "2.3.0"
-  val bootstrapPlayVersion = "9.5.0"
+  val hmrcMongoVersion     = "2.5.0"
+  val bootstrapPlayVersion = "9.9.0"
   val jacksonVersion       = "2.14.3"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                      %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"                %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
-    "org.yaml"                         %  "snakeyaml"                 % "2.3",
-    "org.typelevel"                    %% "cats-core"                 % "2.12.0",
-    "software.amazon.awssdk"           %  "sqs"                       % "2.29.15",
+    "org.yaml"                         %  "snakeyaml"                 % "2.4",
+    "org.typelevel"                    %% "cats-core"                 % "2.13.0",
+    "software.amazon.awssdk"           %  "sqs"                       % "2.30.23",
     "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-yaml"   % jacksonVersion
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.5")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")


### PR DESCRIPTION
`service_mappings.json` is not being maintained (it's unused now), and the fallback was misidentifying repositories. We can better identify which repository the config refers to by the github url, or failing that, the artefact name.